### PR TITLE
Allow turnitin plugin to set anonymity

### DIFF
--- a/lang/en/plagiarism_turnitin.php
+++ b/lang/en/plagiarism_turnitin.php
@@ -115,3 +115,5 @@ $string['turnitin:viewsimilarityscore'] = 'Allow the teacher to view the similar
 $string['userprofileteachercache'] = 'Turnitin teacher course cache';
 $string['userprofileteachercache_desc'] = 'This field is used by the Turnitin plugin to keep a record of all the courses that a teacher has been assigned as a teacher in. - you can clear this field but it may affect performance.';
 $string['errorassigninguser'] = 'An error occured when trying to assign this user to the external Turnitin system - Turnitin links on this page may not work';
+$string['anonymity'] = 'Make student submissions anonymous within Turnitin';
+$string['anonymity_help'] = 'This will prevent teachers from being able to see which student is which by going to the Turnitin interface at submit.ac.uk. Essential if the module is trying to enforce anonymity.';

--- a/lib.php
+++ b/lib.php
@@ -284,7 +284,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                      'plagiarism_draft_submit','plagiarism_compare_student_papers','plagiarism_compare_internet',
                      'plagiarism_compare_journals','plagiarism_compare_institution','plagiarism_report_gen',
                      'plagiarism_exclude_biblio','plagiarism_exclude_quoted','plagiarism_exclude_matches',
-                     'plagiarism_exclude_matches_value');
+                     'plagiarism_exclude_matches_value','plagiarism_anonymity');
     }
 
     public function update_status($course, $cm) {
@@ -1131,6 +1131,9 @@ function turnitin_update_assignment($plagiarismsettings, $plagiarismvalues, $eve
             $tii['exclude_value']     = (isset($plagiarismvalues['plagiarism_exclude_matches_value']) ? $plagiarismvalues['plagiarism_exclude_matches_value'] : '');
             $tii['ainst']             = (!empty($module->intro) ? $module->intro : '');
             $tii['max_points']        = (!empty($module->grade) && $module->grade > 0 ? ceil($module->grade) : '0');
+            if (isset($plagiarismvalues['plagiarism_anonymity'])) {
+                $tii['anon'] = $plagiarismvalues['plagiarism_anonymity'] ? 1 : 0;
+            }
             //$tii['diagnostic'] = '1'; //debug only - uncomment when using in production.
 
             $tiixml = turnitin_post_data($tii, $plagiarismsettings);
@@ -1281,6 +1284,8 @@ function turnitin_get_form_elements($mform) {
         $mform->addElement('text', 'plagiarism_exclude_matches_value', '');
         $mform->addRule('plagiarism_exclude_matches_value', null, 'numeric', null, 'client');
         $mform->disabledIf('plagiarism_exclude_matches_value', 'plagiarism_exclude_matches', 'eq', 0);
+        $mform->addElement('select', 'plagiarism_anonymity', get_string("anonymity", "plagiarism_turnitin"), $ynoptions);
+        $mform->addHelpButton('plagiarism_anonymity', 'anonymity', 'plagiarism_turnitin');
 }
 
 /**


### PR DESCRIPTION
Hi guys. 

I'm doing some work on your Turnitin plugin with James Ballard and I've been asked to share all the code, so here's the first patch. I'm still getting my head around git and github, so let me know if I'm not doing this right!

This commit: Made settings and changed how xml options are sent so that anonymity can be enabled for each module that uses turnitin.
