### PR TITLE
Fixes for some cron errors and a change to how files are stored and retrieved.

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -656,7 +656,7 @@ function turnitin_get_url($tii, $plagiarismsettings, $returnArray=false, $pid=''
     $tii['gmtime']  = turnitin_get_gmtime();
     $tii['aid']     = $plagiarismsettings['turnitin_accountid'];
     $tii['version'] = rawurlencode($CFG->release); //only used internally by TII.
-    $tii['src'] = '14'; //Magic number that identifies this Integration to Turnitin 
+    $tii['src'] = '14'; //Magic number that identifies this Integration to Turnitin
     //prepare $tii for md5string - need to urldecode before generating the md5.
     $tiimd5 = array();
     foreach($tii as $key => $value) {
@@ -960,8 +960,17 @@ function turnitin_get_scores($plagiarismsettings) {
         foreach($files as $file) {
             //set globals.
             $user = $DB->get_record('user', array('id'=>$file->userid));
+            if (!$user) {
+                continue;
+            }
             $coursemodule = $DB->get_record('course_modules', array('id'=>$file->cm));
+            if (!$coursemodule) {
+                continue;
+            }
             $course = $DB->get_record('course', array('id'=>$coursemodule->course));
+            if (!$course) {
+                continue;
+            }
             $mainteacher = $DB->get_field('turnitin_config', 'value', array('cm'=>$file->cm, 'name'=>'turnitin_mainteacher'));
             if (!empty($mainteacher)) {
                 $tii['utp']      = TURNITIN_INSTRUCTOR;
@@ -1088,8 +1097,8 @@ function turnitin_update_assignment($plagiarismsettings, $plagiarismvalues, $eve
             $tii['fcmd'] = TURNITIN_RETURN_XML;
             $tii['fid']  = TURNITIN_CREATE_CLASS; // create class under the given account and assign above user as instructor (fid=2)
             $tiixml = plagiarism_get_xml(turnitin_get_url($tii, $plagiarismsettings));
-            if (!empty($tiixml->rcode[0]) && ($tiixml->rcode[0] == TURNITIN_RESP_CLASS_CREATED_LOGIN or 
-                                              $tiixml->rcode[0] == TURNITIN_RESP_CLASS_CREATED or 
+            if (!empty($tiixml->rcode[0]) && ($tiixml->rcode[0] == TURNITIN_RESP_CLASS_CREATED_LOGIN or
+                                              $tiixml->rcode[0] == TURNITIN_RESP_CLASS_CREATED or
                                               $tiixml->rcode[0] == TURNITIN_RESP_CLASS_UPDATED)) {
                 //save external courseid for future reference.
                 if (!empty($tiixml->classid[0])) {

--- a/lib.php
+++ b/lib.php
@@ -959,16 +959,21 @@ function turnitin_get_scores($plagiarismsettings) {
     if (!empty($files)) {
         foreach($files as $file) {
             //set globals.
+            $valid = true;
             $user = $DB->get_record('user', array('id'=>$file->userid));
             if (!$user) {
-                continue;
+                $valid = false;
             }
             $coursemodule = $DB->get_record('course_modules', array('id'=>$file->cm));
             if (!$coursemodule) {
-                continue;
+                $valid = false;
             }
             $course = $DB->get_record('course', array('id'=>$coursemodule->course));
             if (!$course) {
+                $valid = false;
+            }
+            if (!$valid) {
+                $DB->delete_record('turnitin_files', $file);
                 continue;
             }
             $mainteacher = $DB->get_field('turnitin_config', 'value', array('cm'=>$file->cm, 'name'=>'turnitin_mainteacher'));

--- a/lib.php
+++ b/lib.php
@@ -959,23 +959,16 @@ function turnitin_get_scores($plagiarismsettings) {
     if (!empty($files)) {
         foreach($files as $file) {
             //set globals.
-            $valid = true;
             $user = $DB->get_record('user', array('id'=>$file->userid));
-            if (!$user) {
-                $valid = false;
-            }
             $coursemodule = $DB->get_record('course_modules', array('id'=>$file->cm));
-            if (!$coursemodule) {
-                $valid = false;
+            if ($coursemodule) {
+                $course = $DB->get_record('course', array('id'=>$coursemodule->course));
             }
-            $course = $DB->get_record('course', array('id'=>$coursemodule->course));
-            if (!$course) {
-                $valid = false;
-            }
-            if (!$valid) {
+            if (!($user && $course && $coursemodule)) {
                 $DB->delete_record('turnitin_files', $file);
                 continue;
             }
+
             $mainteacher = $DB->get_field('turnitin_config', 'value', array('cm'=>$file->cm, 'name'=>'turnitin_mainteacher'));
             if (!empty($mainteacher)) {
                 $tii['utp']      = TURNITIN_INSTRUCTOR;

--- a/lib.php
+++ b/lib.php
@@ -1024,23 +1024,24 @@ function turnitin_get_scores($plagiarismsettings) {
  * @param boolean $notify if true, returns a notify call - otherwise just returns the text of the error.
  */
 function turnitin_error_text($statuscode, $notify=true) {
-   $return = '';
-   $statuscode = (int) $statuscode;
-   if (!empty($statuscode)) {
-       if ($statuscode < 100) { //don't return an error state for codes 0-99
-          return '';
-       } else if (($statuscode > 1006 && $statuscode < 1014) or ($statuscode > 1022 && $statuscode < 1025) or $statuscode == 1020) { //these are general errors that a could be useful to students.
-           $return = get_string('tiierror'.$statuscode, 'plagiarism_turnitin');
-       } else if ($statuscode > 1024 && $statuscode < 2000) { //don't have documentation on the other 1000 series errors, so just display a general one.
-           $return = get_string('tiierrorpaperfail', 'plagiarism_turnitin').':'.$statuscode;
-       } else if ($statuscode < 1025 || $statuscode > 2000) { //these are not errors that a student can make any sense out of.
-           $return = get_string('tiiconfigerror', 'plagiarism_turnitin').'('.$statuscode.')';
-       }
-       if (!empty($return) && $notify) {
-           $return = notify($return, 'notifyproblem', 'left', true);
-       }
-   }
-   return $return;
+    global $OUTPUT;
+    $return = '';
+    $statuscode = (int) $statuscode;
+    if (!empty($statuscode)) {
+        if ($statuscode < 100) { //don't return an error state for codes 0-99
+            return '';
+        } else if (($statuscode > 1006 && $statuscode < 1014) or ($statuscode > 1022 && $statuscode < 1025) or $statuscode == 1020) { //these are general errors that a could be useful to students.
+            $return = get_string('tiierror'.$statuscode, 'plagiarism_turnitin');
+        } else if ($statuscode > 1024 && $statuscode < 2000) { //don't have documentation on the other 1000 series errors, so just display a general one.
+            $return = get_string('tiierrorpaperfail', 'plagiarism_turnitin').':'.$statuscode;
+        } else if ($statuscode < 1025 || $statuscode > 2000) { //these are not errors that a student can make any sense out of.
+            $return = get_string('tiiconfigerror', 'plagiarism_turnitin').'('.$statuscode.')';
+        }
+        if (!empty($return) && $notify) {
+            $return = $OUTPUT->notification($return, 'notifyproblem');
+        }
+    }
+    return $return;
 }
 
 /**

--- a/lib.php
+++ b/lib.php
@@ -423,10 +423,8 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
             $items = $DB->get_records_sql($sql, $params);
             foreach ($items as $item) {
                 $fs = get_file_storage();
-                echo  'identifier: '.$item->identifier."\n";
-                $file = $DB->get_record('files', array('pathnamehash' => $item->identifier));
+                $file = $fs->get_file_by_hash($item->identifier);
                 if ($file) {
-                    $file = $fs->get_file_instance($file);
                     $pid = plagiarism_update_record($item->cm, $item->userid, $file->get_pathnamehash(), $item->attempt+1);
                     if (!empty($pid)) {
                         turnitin_send_file($pid, $plagiarismsettings, $file);
@@ -1477,3 +1475,5 @@ function turnitin_event_mod_deleted($eventdata) {
     $turnitin = new plagiarism_plugin_turnitin();
     return $turnitin->event_handler($eventdata);
 }
+
+

--- a/lib.php
+++ b/lib.php
@@ -963,9 +963,11 @@ function turnitin_get_scores($plagiarismsettings) {
             $coursemodule = $DB->get_record('course_modules', array('id'=>$file->cm));
             if ($coursemodule) {
                 $course = $DB->get_record('course', array('id'=>$coursemodule->course));
+            } else {
+                $course = false;
             }
             if (!($user && $course && $coursemodule)) {
-                $DB->delete_record('turnitin_files', $file);
+                $DB->delete_records('turnitin_files', array('id' => $file->id));
                 continue;
             }
 

--- a/lib.php
+++ b/lib.php
@@ -138,7 +138,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
            return false;
         }
 
-        $filehash = $file->get_contenthash();
+        $filehash = $file->get_pathnamehash();
         $modulesql = 'SELECT m.id, m.name, cm.instance'.
                 ' FROM {course_modules} cm' .
                 ' INNER JOIN {modules} m on cm.module = m.id ' .
@@ -423,10 +423,11 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
             $items = $DB->get_records_sql($sql, $params);
             foreach ($items as $item) {
                 $fs = get_file_storage();
-                $file = $DB->get_record('files', array('contenthash' => $item->identifier));
+                echo  'identifier: '.$item->identifier."\n";
+                $file = $DB->get_record('files', array('pathnamehash' => $item->identifier));
                 if ($file) {
                     $file = $fs->get_file_instance($file);
-                    $pid = plagiarism_update_record($item->cm, $item->userid, $file->get_contenthash(), $item->attempt+1);
+                    $pid = plagiarism_update_record($item->cm, $item->userid, $file->get_pathnamehash(), $item->attempt+1);
                     if (!empty($pid)) {
                         turnitin_send_file($pid, $plagiarismsettings, $file);
                     }
@@ -477,7 +478,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                     }
                     if (empty($plagiarismvalues['plagiarism_draft_submit'])) { //check if this is an advanced assignment and shouldn't send the file yet.
                         //TODO - check if this particular file has already been submitted.
-                        $pid = plagiarism_update_record($cmid, $eventdata->userid, $efile->get_contenthash());
+                        $pid = plagiarism_update_record($cmid, $eventdata->userid, $efile->get_pathnamehash());
                         if (!empty($pid)) {
                             $result = turnitin_send_file($pid, $plagiarismsettings, $efile);
                         }
@@ -499,7 +500,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                                 continue;
                             }
                             //TODO: need to check if this file has already been sent! - possible that the file was sent before draft submit was set.
-                            $pid = plagiarism_update_record($cmid, $eventdata->userid, $file->get_contenthash());
+                            $pid = plagiarism_update_record($cmid, $eventdata->userid, $file->get_pathnamehash());
                             if (!empty($pid)) {
                                 $result = turnitin_send_file($pid, $plagiarismsettings, $file);
                             }

--- a/settings.php
+++ b/settings.php
@@ -80,7 +80,7 @@
             if ($plagiarismsettings) { //get tii settings.
                 $tii = array();
                 $tii['utp']   = TURNITIN_INSTRUCTOR;
-                $tii['fcmd']  = TURNITIN_RETURN_XML; 
+                $tii['fcmd']  = TURNITIN_RETURN_XML;
                 $tii['fid']   = TURNITIN_CREATE_USER;
                 $tii = turnitin_get_tii_user($tii, $USER);
                 $tiixml = plagiarism_get_xml(turnitin_get_url($tii, $plagiarismsettings));
@@ -135,14 +135,14 @@
                                                               'instance'=>$tf->instance));
                 if (!empty($cm)) {
                     $newf->cm = $cm->id;
-                    //now get the contenthash for this old file
+                    //now get the pathnamehash for this old file
                     //first get all the files from the assignment module.
                     $modulecontext = get_context_instance(CONTEXT_MODULE, $cm->id);
                     $submission = $DB->get_record('assignment_submissions', array('assignment'=>$this->instance, 'userid'=>$tf->userid));
                     $files = $fs->get_area_files($modulecontext, 'mod_assignment', 'submission', $submission->id);
                     foreach ($files as $file) {
                         if ($file->get_filename()==$tf->filename) {
-                            $newf->identifier = $file->get_contenthash();
+                            $newf->identifier = $file->get_pathnamehash();
                         }
                     }
                     if (!empty($newf->identifier)) {

--- a/turnitin_errors.php
+++ b/turnitin_errors.php
@@ -139,25 +139,14 @@ foreach ($columns as $column) {
 $table->head[] = '';
 
 $table->width = "95%";
+$fs = get_file_storage();
 foreach ($turnitin_files as $tf) {
-    //heavy way to obtain filename and object to allow download link:
-    //TODO: there must be a nicer way to do this.
-    $modulecontext = get_context_instance(CONTEXT_MODULE, $tf->cm);
-    $submission = $DB->get_record('assignment_submissions', array('assignment'=>$tf->cminstance, 'userid'=>$tf->userid));
-    $fs = get_file_storage();
-    $files = $fs->get_area_files($modulecontext->id, 'mod_assignment', 'submission', $submission->id);
-    $filelink = $tf->identifier;
-    if (!empty($files)) {
-        foreach($files as $file) {
-            if ($file->get_pathnamehash()==$tf->identifier) {
-                $filelink = '<a href="'.$CFG->wwwroot.'/files/">'.$file->get_filename()."</a>";
-
-                $url = file_encode_url("$CFG->wwwroot/pluginfile.php", '/'.$modulecontext->id.'/mod_assignment/submission/'.$file->get_itemid(). $file->get_filepath().$file->get_filename(), true);
-                $filelink = html_writer::link($url, $file->get_filename());
-            }
-        }
+    $file = $fs->get_file_by_hash($tf->identifier);
+    if ($file) {
+        $filelink = '<a href="'.$CFG->wwwroot.'/files/">'.$file->get_filename()."</a>";
+        $url = file_encode_url("$CFG->wwwroot/pluginfile.php", '/'.$modulecontext->id.'/mod_assignment/submission/'.$file->get_itemid(). $file->get_filepath().$file->get_filename(), true);
+        $filelink = html_writer::link($url, $file->get_filename());
     }
-
 
     $user = "<a href='".$CFG->wwwroot."/user/profile.php?id=".$tf->userid."'>".fullname($tf)."</a>";
 

--- a/turnitin_errors.php
+++ b/turnitin_errors.php
@@ -79,7 +79,7 @@ if ($resetuser==1 && $id) {
              notify("could not find any files for this submission");
          }
     } else {
-        notify("resubmit function for ".$tfile->moduletype. " not complete yet"); 
+        notify("resubmit function for ".$tfile->moduletype. " not complete yet");
     }
     //TODO: trigger event for this file
 
@@ -149,7 +149,7 @@ foreach ($turnitin_files as $tf) {
     $filelink = $tf->identifier;
     if (!empty($files)) {
         foreach($files as $file) {
-            if ($file->get_contenthash()==$tf->identifier) {
+            if ($file->get_pathnamehash()==$tf->identifier) {
                 $filelink = '<a href="'.$CFG->wwwroot.'/files/">'.$file->get_filename()."</a>";
 
                 $url = file_encode_url("$CFG->wwwroot/pluginfile.php", '/'.$modulecontext->id.'/mod_assignment/submission/'.$file->get_itemid(). $file->get_filepath().$file->get_filename(), true);
@@ -160,7 +160,7 @@ foreach ($turnitin_files as $tf) {
 
 
     $user = "<a href='".$CFG->wwwroot."/user/profile.php?id=".$tf->userid."'>".fullname($tf)."</a>";
-    
+
     $reset = '<a href="turnitin_errors.php?reset=1&id='.$tf->id.'">'.get_string('resubmit','plagiarism_turnitin').'</a> | '.
              '<a href="turnitin_errors.php?delete=1&id='.$tf->id.'">'.get_string('delete').'</a>';
     $cmlink = '<a href="'.$CFG->wwwroot.'/'.$tf->moduletype.'/view.php?id='.$tf->cm.'">'.get_string('module', 'plagiarism_turnitin').'</a>';

--- a/version.php
+++ b/version.php
@@ -15,6 +15,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-$plugin->version =  2011083102;
+$plugin->version =  2011111000;
 $plugin->requires = 2010042803;
 $plugin->cron     = 0;


### PR DESCRIPTION
Hi Dan.

I got some errors in cron when my dev machine had stuff in the event queue for a module I'd deleted. This fixes them by skipping and deleting any turnitin files that are orphaned.

I have also changed the turnitin files table to use the file pathname hash, not the contents hash. This allows direct retrieval of the files without any faffing about looping over all the area files and also acts as a unique identifier, whereas content hash can be duplicated if the same file is uploaded in two places, so it's not that useful.

I've changed all the places that referred to the contenthash, but you may need to double check this as I'm not 100% familiar with the code and may have not noticed something.

The upgrade seems to work for me but it may need a bit of testing to make sure.

Matt
