### PR TITLE
Turnitin XML response elements give SQL errors when written to an Oracle database

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -867,7 +867,7 @@ function turnitin_send_file($pid, $plagiarismsettings, $file) {
          mtrace('could not create user/login to turnitin code:'.$tiixml->rcode[0]);
     } else {
         $plagiarism_file = $DB->get_record('turnitin_files', array('id'=>$pid)); //make sure we get latest record as it may have changed
-        $plagiarism_file->statuscode = $tiixml->rcode[0];
+        $plagiarism_file->statuscode = (string)$tiixml->rcode[0];
         if (! $DB->update_record('turnitin_files', $plagiarism_file)) {
             debugging("Error updating turnitin_files record");
         }
@@ -891,7 +891,7 @@ function turnitin_send_file($pid, $plagiarismsettings, $file) {
             mtrace('could not enrol user in turnitin class code:'.$tiixml->rcode[0]);
         } else {
             $plagiarism_file = $DB->get_record('turnitin_files', array('id'=>$pid)); //make sure we get latest record as it may have changed
-            $plagiarism_file->statuscode = $tiixml->rcode[0];
+            $plagiarism_file->statuscode = (string)$tiixml->rcode[0];
             if (! $DB->update_record('turnitin_files', $plagiarism_file)) {
                 debugging("Error updating turnitin_files record");
             }
@@ -913,13 +913,13 @@ function turnitin_send_file($pid, $plagiarismsettings, $file) {
             $tiixml = turnitin_post_data($tii, $plagiarismsettings, $file, $pid);
             if ($tiixml->rcode[0] == TURNITIN_RESP_PAPER_SENT) { //we need to return the oid and save it!
                 $plagiarism_file = $DB->get_record('turnitin_files', array('id'=>$pid)); //make sure we get latest record as it may have changed
-                $plagiarism_file->externalid = $tiixml->objectID[0];
+                $plagiarism_file->externalid = (string)$tiixml->objectID[0];
                 debugging("success uploading assignment", DEBUG_DEVELOPER);
             } else {
                 $plagiarism_file = $DB->get_record('turnitin_files', array('id'=>$pid)); //make sure we get latest record as it may have changed
                 debugging("failed to upload assignment errorcode".$tiixml->rcode[0]);
             }
-            $plagiarism_file->statuscode = $tiixml->rcode[0];
+            $plagiarism_file->statuscode = (string)$tiixml->rcode[0];
             if (! $DB->update_record('turnitin_files', $plagiarism_file)) {
                 debugging("Error updating turnitin_files record");
             }
@@ -982,7 +982,7 @@ function turnitin_get_scores($plagiarismsettings) {
             $tiixml = plagiarism_get_xml(turnitin_get_url($tii, $plagiarismsettings, false, $file->id));
             if ($tiixml->rcode[0] == TURNITIN_RESP_SCORE_RECEIVED) { //this is the success code for uploading a file. - we need to return the oid and save it!
                 $file = $DB->get_record('turnitin_files', array('id'=>$file->id)); //make sure we get latest record as it may have changed
-                $file->similarityscore = $tiixml->originalityscore[0];
+                $file->similarityscore = (string)$tiixml->originalityscore[0];
                 $file->statuscode = 'success';
                 if (! $DB->update_record('turnitin_files', $file)) {
                     debugging("Error updating turnitin_files record");
@@ -991,7 +991,7 @@ function turnitin_get_scores($plagiarismsettings) {
                 mtrace('similarity report not available yet for fileid:'.$file->id. " code:".$tiixml->rcode[0]);
             } else if (!empty($tiixml->rcode[0])) {
                 mtrace('similarity report check failed for fileid:'.$file->id. " code:".$tiixml->rcode[0]);
-                $file->statuscode = $tiixml->rcode[0];
+                $file->statuscode = (string)$tiixml->rcode[0];
                 if (! $DB->update_record('turnitin_files', $file)) {
                     debugging("Error updating turnitin_files record");
                 }
@@ -1169,11 +1169,11 @@ function turnitin_update_assignment($plagiarismsettings, $plagiarismvalues, $eve
                         $configval = new stdclass();
                         $configval->cm = $cm->id;
                         $configval->name = 'turnitin_assignid';
-                        $configval->value = $tiixml->assignmentid[0];
+                        $configval->value = (string)$tiixml->assignmentid[0];
                         $DB->insert_record('turnitin_config', $configval);
                     } else {
                         $configval = $DB->get_record('turnitin_config', array('cm'=> $cm->id, 'name'=> 'turnitin_assignid'));
-                        $configval->value = $tiixml->assignmentid[0];
+                        $configval->value = (string)$tiixml->assignmentid[0];
                         $DB->update_record('turnitin_config', $configval);
                     }
                 }


### PR DESCRIPTION
Queries fail with an exception like shown below. The most obvious symptom of the issue is papers being created repeatedly in Turnitin at each run of the cron job. The problem is the Oracle PHP driver does not appear to implicitly take the string value of a SimpleXMLElement object that's being bound to a parameter. I added casts to string on the objects being used as parameters for database operations and this solves the issue.

```
Error writing to database
 * line 268 of /lib/dml/oci_native_moodle_database.php: call to moodle_database->query_end()
 * line 1236 of /lib/dml/oci_native_moodle_database.php: call to oci_native_moodle_database->query_end()
 * line 1279 of /lib/dml/oci_native_moodle_database.php: call to oci_native_moodle_database->insert_record_raw()
 * line 1177 of /plagiarism/turnitin/lib.php: call to oci_native_moodle_database->insert_record()
 * line 464 of /plagiarism/turnitin/lib.php: call to turnitin_update_assignment()
 * line 1468 of /plagiarism/turnitin/lib.php: call to plagiarism_plugin_turnitin->event_handler()
 * line ? of unknownfile: call to turnitin_event_mod_created()
 * line 296 of /lib/eventslib.php: call to call_user_func()
 * line 340 of /lib/eventslib.php: call to events_dispatch()
 * line 448 of /lib/eventslib.php: call to events_process_queued_handler()
 * line 165 of /lib/cronlib.php: call to events_cron()
 * line 61 of /admin/cli/cron.php: call to cron_run()
ORA-01008: not all variables bound
INSERT INTO z_turnitin_config (cm,name,value) VALUES (:cm,:name,:value) RETURNING id INTO :oracle_id
[array (
  \'cm\' => \'150\',
  \'name\' => \'turnitin_assignid\',
  \'value\' => 
  SimpleXMLElement::__set_state(array(
     0 => \'13789861\',
  )),
)]
```
