### PR TITLE
Fix start time

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -135,6 +135,25 @@ function xmldb_plagiarism_turnitin_upgrade($oldversion) {
 
     }
 
+    if ($oldversion < 2011111001) {
+        // All assignments need to have a start time
+
+        $existingassignments = $DB->get_records_sql('turnitin_config', array('name' => 'turnitin_assignid'));
+
+        foreach ($existingassignments as $assignment) {
+            $setting = new stdClass();
+            $setting->cm = $assignment->cm;
+            $setting->name = 'turnitin_dtstart';
+            // Doesn't matter that this is not the same as the actual turnitin start date. It just needs to be
+            // ahead of the actual one and in the past relative to any future submitted files.
+            $setting->value = time();
+            $DB->insert_record('turnitin_config', $setting);
+        }
+
+        upgrade_plugin_savepoint(true, 2011111001, 'plagiarism', 'turnitin');
+
+    }
+
 
     return true;
 }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -144,16 +144,27 @@ function xmldb_plagiarism_turnitin_upgrade($oldversion) {
             $setting = new stdClass();
             $setting->cm = $assignment->cm;
             $setting->name = 'turnitin_dtstart';
-            // Doesn't matter that this is not the same as the actual turnitin start date. It just needs to be
-            // ahead of the actual one and in the past relative to any future submitted files.
-            $setting->value = time();
+
+            $coursemodule = $DB->get_record('course_modules', array('id' => $assignment->cm));
+            if ($coursemodule) {
+                $modulename = $DB->get_field('modules', 'name', array('id' => $coursemodule->module));
+                $module = $DB->get_record($modulename, array('id' => $coursemodule->instance));
+            }
+            if (!empty($module->timeavailable)) {
+                $setting->value = $module->timeavailable;
+            } else if (!empty($module->timecreated)) {
+                $setting->value = $module->timecreated;
+            } else {
+                // Doesn't matter hugely that this is not the same as the actual turnitin start date. It just needs
+                // to be ahead of the actual one and in the past relative to any future submitted files.
+                $setting->value = time();
+            }
             $DB->insert_record('turnitin_config', $setting);
         }
 
         upgrade_plugin_savepoint(true, 2011111001, 'plagiarism', 'turnitin');
 
     }
-
 
     return true;
 }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -138,7 +138,7 @@ function xmldb_plagiarism_turnitin_upgrade($oldversion) {
     if ($oldversion < 2011111001) {
         // All assignments need to have a start time
 
-        $existingassignments = $DB->get_records_sql('turnitin_config', array('name' => 'turnitin_assignid'));
+        $existingassignments = $DB->get_records('turnitin_config', array('name' => 'turnitin_assignid'));
 
         foreach ($existingassignments as $assignment) {
             $setting = new stdClass();

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -146,6 +146,7 @@ function xmldb_plagiarism_turnitin_upgrade($oldversion) {
             $setting->name = 'turnitin_dtstart';
 
             $coursemodule = $DB->get_record('course_modules', array('id' => $assignment->cm));
+            $module = false;
             if ($coursemodule) {
                 $modulename = $DB->get_field('modules', 'name', array('id' => $coursemodule->module));
                 $module = $DB->get_record($modulename, array('id' => $coursemodule->instance));

--- a/lang/en/plagiarism_turnitin.php
+++ b/lang/en/plagiarism_turnitin.php
@@ -119,3 +119,5 @@ $string['anonymity'] = 'Make student submissions anonymous within Turnitin';
 $string['anonymity_help'] = 'This will prevent teachers from being able to see which student is which by going to the Turnitin interface at submit.ac.uk. Essential if the module is trying to enforce anonymity.';
 $string['missingkey'] = 'Turnitin Secret Key not set!';
 $string['fileopenerror'] = 'error trying to open plagiarism XML file! {$a}';
+$string['beingprocessed'] = 'File was uploaded successfully and is currently being processed by turnitin';
+$string['queued'] = 'Queued for submission to Turnitin';

--- a/lib.php
+++ b/lib.php
@@ -1102,7 +1102,7 @@ function turnitin_update_assignment($plagiarismsettings, $plagiarismvalues, $eve
                 $tii['fcmd'] = TURNITIN_RETURN_XML;
                 // New assignments cannout have a start date/time in the past (as judged by TII servers)
                 // add an hour to account for possibility of our clock being fast, or TII clock being slow.
-                $tii['dtstart'] = rawurlencode(date('Y-m-d H:i:s', time()+60*60));
+                $tii['dtstart'] = rawurlencode(date('Y-m-d H:i:s', time()));
                 $tii['dtdue'] = rawurlencode(date('Y-m-d H:i:s', time()+(365 * 24 * 60 * 60)));
             } else {
                 $tii['assignid'] = $plagiarismvalues['turnitin_assignid'];

--- a/lib.php
+++ b/lib.php
@@ -1097,13 +1097,14 @@ function turnitin_update_assignment($plagiarismsettings, $plagiarismvalues, $eve
             }
             //now create Assignment in Class
             //first check if this assignment has already been created
+            $tunitindateformat = 'Y-m-d H:i:s';
             if (empty($plagiarismvalues['turnitin_assignid'])) {
                 $tii['assignid']   = "a_".time().rand(10,5000); //some unique random id only used once.
                 $tii['fcmd'] = TURNITIN_RETURN_XML;
                 // New assignments cannot have a start date/time in the past (as judged by TII servers)
                 // add an hour to account for possibility of our clock being fast, or TII clock being slow.
                 $timestamp = strtotime('+10 minutes');
-                $tii['dtstart'] = rawurlencode(date('Y-m-d H:i:s', $timestamp));
+                $tii['dtstart'] = rawurlencode(date($tunitindateformat, $timestamp));
                 // Store the start time. We can't make it instant in case Turnitin is flaky and
                 // thinks we are trying to start in the past. Don't want to submit file till it is
                 // definitely in the past though.
@@ -1113,24 +1114,24 @@ function turnitin_update_assignment($plagiarismsettings, $plagiarismvalues, $eve
                 $timestartconfig->value = $timestamp;
                 $DB->insert_record('turnitin_config', $timestartconfig);
 
-                $tii['dtdue'] = rawurlencode(date('Y-m-d H:i:s', strtotime('+1 year')));
+                $tii['dtdue'] = rawurlencode(date($tunitindateformat, strtotime('+1 year')));
             } else {
                 $tii['assignid'] = $plagiarismvalues['turnitin_assignid'];
                 $tii['fcmd'] = TURNITIN_UPDATE_RETURN_XML;
                 if (!empty($module->timeavailable)) {
-                    $tii['dtstart']  = rawurlencode(date('Y-m-d H:i:s', $module->timeavailable));
+                    $tii['dtstart']  = rawurlencode(date($tunitindateformat, $module->timeavailable));
                 } else if (!empty($eventdata->timeavailable)) {
-                    $tii['dtstart']  = rawurlencode(date('Y-m-d H:i:s', $eventdata->timeavailable));
+                    $tii['dtstart']  = rawurlencode(date($tunitindateformat, $eventdata->timeavailable));
                 } else if (!empty($module->timecreated)) {
-                    $tii['dtstart']  = rawurlencode(date('Y-m-d H:i:s', $module->timecreated));
+                    $tii['dtstart']  = rawurlencode(date($tunitindateformat, $module->timecreated));
                 } else {
                     // Without this, turnitin will throw an error, even on update
-                    $tii['dtstart']  = rawurlencode(date('Y-m-d H:i:s', time()));
+                    $tii['dtstart']  = rawurlencode(date($tunitindateformat, time()));
                 }
                 if (empty($module->timedue)) {
-                    $tii['dtdue'] = rawurlencode(date('Y-m-d H:i:s', time()+(365 * 24 * 60 * 60)));
+                    $tii['dtdue'] = rawurlencode(date($tunitindateformat, strtotime('+1 year')));
                 } else {
-                    $tii['dtdue']    = rawurlencode(date('Y-m-d H:i:s', $module->timedue));
+                    $tii['dtdue']    = rawurlencode(date($tunitindateformat, $module->timedue));
                 }
             }
             $tii['assign']   = turnitin_get_assign_name($module->name, $cm->id); //assignment name stored in TII
@@ -1187,10 +1188,10 @@ function turnitin_update_assignment($plagiarismsettings, $plagiarismvalues, $eve
                     $tii['assignid'] = $tiixml->assignmentid[0];
                     $tii['fcmd'] = TURNITIN_UPDATE_RETURN_XML;
                     if (!empty($module->timeavailable)) {
-                        $tii['dtstart']  = rawurlencode(date('Y-m-d H:i:s', $module->timeavailable));
+                        $tii['dtstart']  = rawurlencode(date($tunitindateformat, $module->timeavailable));
                     }
                     if (!empty($module->timedue)) {
-                        $tii['dtdue']    = rawurlencode(date('Y-m-d H:i:s', $module->timedue));
+                        $tii['dtdue']    = rawurlencode(date($tunitindateformat, $module->timedue));
                     }
                 }
                 $tiixml = turnitin_post_data($tii, $plagiarismsettings);

--- a/lib.php
+++ b/lib.php
@@ -857,7 +857,7 @@ function turnitin_send_file($pid, $plagiarismsettings, $file) {
         return true;
     }
     $dtstart = $DB->get_record('turnitin_config', array('cm' => $cm->id, 'name' => 'turnitin_dtstart'));
-    if (!empty($dtstart) && $dtstart->value+600 > time()) {
+    if (!empty($dtstart) && $dtstart->value > time()) {
         mtrace("Warning: assignment start date is too early ".date('Y-m-d H:i:s', $dtstart->value)." in course $course->shortname assignment $module->name will delay sending files until next cron");
         return false; //TODO: check that this doesn't cause a failure in cron
     }

--- a/lib.php
+++ b/lib.php
@@ -455,8 +455,8 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
 
             // If the assignment has only just been set up, we don't want to try to submit to it, or
             // we'll get a 1001 error
-            $assignmentstarttime = $DB->get_field('turnitin_config', array('cm' => $cm->id,
-                                                                           'name' => 'turnitin_dtsart'));
+            $assignmentstarttime = $DB->get_field('turnitin_config', 'value', array('cm' => $cm->id,
+                                                                                    'name' => 'turnitin_dtsart'));
             if (strtotime('+5 minutes', $assignmentstarttime) < time()) {
                 // Probably not set up properly - we need to allow for wonky server clocks.
                 return $result;
@@ -1128,16 +1128,8 @@ function turnitin_update_assignment($plagiarismsettings, $plagiarismvalues, $eve
             } else {
                 $tii['assignid'] = $plagiarismvalues['turnitin_assignid'];
                 $tii['fcmd'] = TURNITIN_UPDATE_RETURN_XML;
-                if (!empty($module->timeavailable)) {
-                    $tii['dtstart']  = rawurlencode(date($tunitindateformat, $module->timeavailable));
-                } else if (!empty($eventdata->timeavailable)) {
-                    $tii['dtstart']  = rawurlencode(date($tunitindateformat, $eventdata->timeavailable));
-                } else if (!empty($module->timecreated)) {
-                    $tii['dtstart']  = rawurlencode(date($tunitindateformat, $module->timecreated));
-                } else {
-                    // Without this, turnitin will throw an error, even on update
-                    $tii['dtstart']  = rawurlencode(date($tunitindateformat, time()));
-                }
+                $tii['dtstart']  = $DB->get_field('turnitin_config', 'value', array('cm' => $cm->id,
+                                                                                    'name' => 'turnitin_dtsart'));
                 if (empty($module->timedue)) {
                     $tii['dtdue'] = rawurlencode(date($tunitindateformat, strtotime('+1 year')));
                 } else {

--- a/lib.php
+++ b/lib.php
@@ -1100,17 +1100,20 @@ function turnitin_update_assignment($plagiarismsettings, $plagiarismvalues, $eve
             if (empty($plagiarismvalues['turnitin_assignid'])) {
                 $tii['assignid']   = "a_".time().rand(10,5000); //some unique random id only used once.
                 $tii['fcmd'] = TURNITIN_RETURN_XML;
-                // New assignments cannout have a start date/time in the past (as judged by TII servers)
+                // New assignments cannot have a start date/time in the past (as judged by TII servers)
                 // add an hour to account for possibility of our clock being fast, or TII clock being slow.
                 $tii['dtstart'] = rawurlencode(date('Y-m-d H:i:s', time()));
                 $tii['dtdue'] = rawurlencode(date('Y-m-d H:i:s', time()+(365 * 24 * 60 * 60)));
             } else {
                 $tii['assignid'] = $plagiarismvalues['turnitin_assignid'];
                 $tii['fcmd'] = TURNITIN_UPDATE_RETURN_XML;
-                if (empty($module->timeavailable)) {
-                    $tii['dtstart'] = rawurlencode(date('Y-m-d H:i:s', time()));
-                } else {
+                if (!empty($module->timeavailable)) {
                     $tii['dtstart']  = rawurlencode(date('Y-m-d H:i:s', $module->timeavailable));
+                } else if (!empty($eventdata->timeavailable)) {
+                    $tii['dtstart']  = rawurlencode(date('Y-m-d H:i:s', $eventdata->timeavailable));
+                } else {
+                    // TODO is this really necessary on an update?
+                    $tii['dtstart']  = rawurlencode(date('Y-m-d H:i:s', time()));
                 }
                 if (empty($module->timedue)) {
                     $tii['dtdue'] = rawurlencode(date('Y-m-d H:i:s', time()+(365 * 24 * 60 * 60)));

--- a/lib.php
+++ b/lib.php
@@ -1102,8 +1102,18 @@ function turnitin_update_assignment($plagiarismsettings, $plagiarismvalues, $eve
                 $tii['fcmd'] = TURNITIN_RETURN_XML;
                 // New assignments cannot have a start date/time in the past (as judged by TII servers)
                 // add an hour to account for possibility of our clock being fast, or TII clock being slow.
-                $tii['dtstart'] = rawurlencode(date('Y-m-d H:i:s', time()));
-                $tii['dtdue'] = rawurlencode(date('Y-m-d H:i:s', time()+(365 * 24 * 60 * 60)));
+                $timestamp = strtotime('+10 minutes');
+                $tii['dtstart'] = rawurlencode(date('Y-m-d H:i:s', $timestamp));
+                // Store the start time. We can't make it instant in case Turnitin is flaky and
+                // thinks we are trying to start in the past. Don't want to submit file till it is
+                // definitely in the past though.
+                $timestartconfig = new stdClass();
+                $timestartconfig->cm = $cm->id;
+                $timestartconfig->name = 'turnitin_dtstart';
+                $timestartconfig->value = $timestamp;
+                $DB->insert_record('turnitin_config', $timestartconfig);
+
+                $tii['dtdue'] = rawurlencode(date('Y-m-d H:i:s', strtotime('+1 year')));
             } else {
                 $tii['assignid'] = $plagiarismvalues['turnitin_assignid'];
                 $tii['fcmd'] = TURNITIN_UPDATE_RETURN_XML;

--- a/lib.php
+++ b/lib.php
@@ -461,7 +461,10 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
             // If the assignment has only just been set up, we don't want to try to submit to it, or
             // we'll get a 1001 error
             $assignmentstarttime = $DB->get_field('turnitin_config', 'value', array('cm' => $cm->id,
-                                                                                    'name' => 'turnitin_dtsart'));
+                                                                                    'name' => 'turnitin_dtstart'));
+            if (!$assignmentstarttime) {
+                // Older assignments won't have this set up yet
+            }
             if ($assignmentstarttime < time()) {
                 // May not be set up properly - we need to allow for wonky server clocks.
                 return $result;
@@ -1137,7 +1140,7 @@ function turnitin_update_assignment($plagiarismsettings, $plagiarismvalues, $eve
                 $tii['assignid'] = $plagiarismvalues['turnitin_assignid'];
                 $tii['fcmd'] = TURNITIN_UPDATE_RETURN_XML;
                 $tii['dtstart']  = $DB->get_field('turnitin_config', 'value', array('cm' => $cm->id,
-                                                                                    'name' => 'turnitin_dtsart'));
+                                                                                    'name' => 'turnitin_dtstart'));
                 if (empty($module->timedue)) {
                     $tii['dtdue'] = rawurlencode(date($tunitindateformat, strtotime('+1 year')));
                 } else {

--- a/lib.php
+++ b/lib.php
@@ -453,7 +453,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
            return  turnitin_update_assignment($plagiarismsettings, $plagiarismvalues, $eventdata, 'delete');
         } else if ($eventdata->eventtype=="file_uploaded") {
             // check if the module associated with this event still exists
-            $cm = $DB->record_exists('course_modules', array('id' => $eventdata->cmid));
+            $cm = $DB->get_record('course_modules', array('id' => $eventdata->cmid));
             if (!$cm) {
                 return $result;
             }

--- a/lib.php
+++ b/lib.php
@@ -1114,7 +1114,7 @@ function turnitin_update_assignment($plagiarismsettings, $plagiarismvalues, $eve
                 } else if (!empty($module->timecreated)) {
                     $tii['dtstart']  = rawurlencode(date('Y-m-d H:i:s', $module->timecreated));
                 } else {
-                    // TODO is this really necessary on an update?
+                    // Without this, turnitin will throw an error, even on update
                     $tii['dtstart']  = rawurlencode(date('Y-m-d H:i:s', time()));
                 }
                 if (empty($module->timedue)) {

--- a/lib.php
+++ b/lib.php
@@ -462,10 +462,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
             // we'll get a 1001 error
             $assignmentstarttime = $DB->get_field('turnitin_config', 'value', array('cm' => $cm->id,
                                                                                     'name' => 'turnitin_dtstart'));
-            if (!$assignmentstarttime) {
-                // Older assignments won't have this set up yet
-            }
-            if ($assignmentstarttime < time()) {
+            if ($assignmentstarttime > time()) {
                 // May not be set up properly - we need to allow for wonky server clocks.
                 return $result;
             }

--- a/lib.php
+++ b/lib.php
@@ -1111,6 +1111,8 @@ function turnitin_update_assignment($plagiarismsettings, $plagiarismvalues, $eve
                     $tii['dtstart']  = rawurlencode(date('Y-m-d H:i:s', $module->timeavailable));
                 } else if (!empty($eventdata->timeavailable)) {
                     $tii['dtstart']  = rawurlencode(date('Y-m-d H:i:s', $eventdata->timeavailable));
+                } else if (!empty($module->timecreated)) {
+                    $tii['dtstart']  = rawurlencode(date('Y-m-d H:i:s', $module->timecreated));
                 } else {
                     // TODO is this really necessary on an update?
                     $tii['dtstart']  = rawurlencode(date('Y-m-d H:i:s', time()));

--- a/version.php
+++ b/version.php
@@ -15,6 +15,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-$plugin->version =  2011111000;
+$plugin->version =  2011111001;
 $plugin->requires = 2010042803;
 $plugin->cron     = 0;


### PR DESCRIPTION
We have been getting errors using a non-assignment custom module, because every time the module form was edited, it would set the timestart back to time(), messing up the submission of work that cron had not processed yet. Also, we found that newly created items would not accept work for the first hour, which made testing impossible. The small delay that cron introduces when a new assignment is created seems to make clock-sync issues between the server and turnitin not matter.
