### PR TITLE
Remove typo in the styles for rank 9 that created a white text on white ...

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -45,7 +45,7 @@ span.plagiarismreport span.rank8 {
        background: #22B573;
 }
 
-sp17an.plagiarismreport span.rank9 {
+span.plagiarismreport span.rank9 {
        background: #00AEE3;
 }
 


### PR DESCRIPTION
...There is a superfluous '17' error in the styles.css that ends up with a white text on white background display
