### PR TITLE
MDL-31028: now works with pathnamehashes

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -574,14 +574,15 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                 $fileresult = false;
                 $fs = get_file_storage();
                 $efile = $fs->get_file_by_hash($hash);
-                if ($efile->get_filename() ==='.') {
-                    // This is a directory - nothing to do.
-                    continue;
-                }
 
                 //hacky way to check file still exists
                 if (empty($efile)) {
                     mtrace("nofilefound!");
+                    continue;
+                }
+
+                if ($efile->get_filename() ==='.') {
+                    // This is a directory - nothing to do.
                     continue;
                 }
 

--- a/lib.php
+++ b/lib.php
@@ -130,7 +130,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
      * @param stored_file $file file object describing a moodle file which was submited to TII
      * @return mixed - false if no info available, or an array describing what's known about the TII submission
      */
-    public function get_file_results($cmid, $userid, $file) {
+    public function get_file_results($cmid, $userid, stored_file $file) {
         global $DB, $USER, $COURSE, $OUTPUT;
 
         $plagiarismsettings = $this->get_settings();

--- a/lib.php
+++ b/lib.php
@@ -575,13 +575,10 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                 $fs = get_file_storage();
                 $efile = $fs->get_file_by_hash($hash);
 
-                //hacky way to check file still exists
                 if (empty($efile)) {
                     mtrace("nofilefound!");
                     continue;
-                }
-
-                if ($efile->get_filename() ==='.') {
+                } else if ($efile->get_filename() ==='.') {
                     // This is a directory - nothing to do.
                     continue;
                 }


### PR DESCRIPTION
Turnitin now uses pathnamehashes rather than file object from eventdata.
