### PR TITLE
Fix stalled events 22

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -583,9 +583,12 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                     $modulecontext = get_context_instance(CONTEXT_MODULE, $eventdata->cmid);
                     $fs = get_file_storage();
                     $result = true;
-                    if ($files = $fs->get_area_files($modulecontext->id, 'mod_'.$modulename, 'submission', $submission->id, "timemodified", false)) {
+                    $files = $fs->get_area_files($modulecontext->id, 'mod_'.$modulename,
+                                                 'submission', $submission->id, "timemodified", false);
+                    if ($files) {
                         mtrace("files");
                         foreach ($files as $file) {
+                            /* @var stored_file $file */
                             $pid = plagiarism_update_record($cmid, $eventdata->userid, $file->get_pathnamehash());
                             if (!empty($pid)) {
                                 $fileresult = turnitin_send_file($pid, $plagiarismsettings, $file);

--- a/lib.php
+++ b/lib.php
@@ -473,6 +473,10 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
             && !empty($plagiarismsettings['turnitin_attemptcodes'])) {
 
             $attemptcodes = explode(',', trim($plagiarismsettings['turnitin_attemptcodes']));
+            // In case people have used whitespace in their list of comma separated values.
+            foreach ($attemptcodes as &$code) {
+                $code = trim($code);
+            }
             list($usql, $params) = $DB->get_in_or_equal($attemptcodes);
             $sql = "SELECT tf.*
                     FROM {plagiarism_turnitin_files} tf, {course_modules} cm

--- a/lib.php
+++ b/lib.php
@@ -919,20 +919,21 @@ function turnitin_send_file($pid, $plagiarismsettings, $file) {
     //get information about this file
     $plagiarism_file = $DB->get_record('plagiarism_turnitin_files', array('id'=>$pid));
     $invalidrecord = false;
-    if (!$user = $DB->get_record('user', array('id'=>$plagiarism_file->userid))) {
-        debugging("invalid userid! - userid:".$plagiarism_file->userid." Module:".$moduletype." Fileid:".$plagiarism_file->id);
-        $invalidrecord = true;
-    }
+
     if (!$cm = $DB->get_record('course_modules', array('id'=>$plagiarism_file->cm))) {
         debugging("invalid cmid! ".$plagiarism_file->cm." Fileid:".$plagiarism_file->id);
+        $invalidrecord = true;
+    }
+    if (!$moduletype = $DB->get_field('modules', 'name', array('id' => $cm->module))) {
+        debugging("invalid moduleid! - moduleid:".$cm->module." Module:".$moduletype." Fileid:".$plagiarism_file->id);
         $invalidrecord = true;
     }
     if (!$course = $DB->get_record('course', array('id'=>$cm->course))) {
         debugging("invalid cmid! - courseid:".$cm->course." Module:".$moduletype." Fileid:".$plagiarism_file->id);
         $invalidrecord = true;
     }
-    if (!$moduletype = $DB->get_field('modules', 'name', array('id'=>$cm->module))) {
-        debugging("invalid moduleid! - moduleid:".$cm->module." Module:".$moduletype." Fileid:".$plagiarism_file->id);
+    if (!$user = $DB->get_record('user', array('id' => $plagiarism_file->userid))) {
+        debugging("invalid userid! - userid:".$plagiarism_file->userid." Module:".$moduletype." Fileid:".$plagiarism_file->id);
         $invalidrecord = true;
     }
     if (!$module = $DB->get_record($moduletype, array('id'=>$cm->instance))) {

--- a/lib.php
+++ b/lib.php
@@ -582,9 +582,9 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                     $submission = $assignmentbase->get_submission($eventdata->userid);
                     $modulecontext = get_context_instance(CONTEXT_MODULE, $eventdata->cmid);
                     $fs = get_file_storage();
+                    $result = true;
                     if ($files = $fs->get_area_files($modulecontext->id, 'mod_'.$modulename, 'submission', $submission->id, "timemodified", false)) {
                         mtrace("files");
-                        $result = true;
                         foreach ($files as $file) {
                             $pid = plagiarism_update_record($cmid, $eventdata->userid, $file->get_pathnamehash());
                             if (!empty($pid)) {

--- a/lib.php
+++ b/lib.php
@@ -25,7 +25,7 @@
  */
 
 if (!defined('MOODLE_INTERNAL')) {
-    die('Direct access to this script is forbidden.');    ///  It must be included from a Moodle page
+    die('Direct access to this script is forbidden.');  // It must be included from a Moodle page.
 }
 define('PLAGIARISM_TII_SHOW_NEVER', 0);
 define('PLAGIARISM_TII_SHOW_ALWAYS', 1);
@@ -34,15 +34,15 @@ define('PLAGIARISM_TII_SHOW_CLOSED', 2);
 define('PLAGIARISM_TII_DRAFTSUBMIT_IMMEDIATE', 0);
 define('PLAGIARISM_TII_DRAFTSUBMIT_FINAL', 1);
 
-//Turnitin fcmd types - return values.
+//  fcmd types - return values.
 define('TURNITIN_LOGIN', 1);
 define('TURNITIN_RETURN_XML', 2);
 define('TURNITIN_UPDATE_RETURN_XML', 3);
-// Turnitin user types
+// Turnitin user types.
 define('TURNITIN_STUDENT', 1);
 define('TURNITIN_INSTRUCTOR', 2);
 define('TURNITIN_ADMIN', 3);
-//Turnitin API actions.
+// Turnitin API actions.
 define('TURNITIN_CREATE_USER', 1);
 define('TURNITIN_CREATE_CLASS', 2);
 define('TURNITIN_JOIN_CLASS', 3);
@@ -50,7 +50,7 @@ define('TURNITIN_CREATE_ASSIGNMENT', 4);
 define('TURNITIN_SUBMIT_PAPER', 5);
 define('TURNITIN_RETURN_REPORT', 6);
 define('TURNITIN_VIEW_SUBMISSION', 7);
-define('TURNITIN_DELETE_SUBMISSION', 8); //unlikely to need this.
+define('TURNITIN_DELETE_SUBMISSION', 8); // Unlikely to need this.
 define('TURNITIN_LIST_SUBMISSIONS', 10);
 define('TURNITIN_CHECK_SUBMISSION', 11);
 define('TURNITIN_ADMIN_STATS', 12);
@@ -59,26 +59,25 @@ define('TURNITIN_REPORT_TIME', 14);
 define('TURNITIN_SUBMISSION_SCORE', 15);
 define('TURNITIN_START_SESSION', 17);
 define('TURNITIN_END_SESSION', 18);
-//Turnitin allowed file types
+// Turnitin allowed file types.
 define('TURNITIN_TYPE_TEXT', 1);
 define('TURNITIN_TYPE_FILE', 2);
 
-//Turnitin Response codes - there are many more of these, just not used directly.
-//
-define('TURNITIN_RESP_USER_CREATED', 11); // User creation successful, do not send to login
-define('TURNITIN_RESP_CLASS_CREATED_LOGIN', 20); // Class created successfully, send to login
-define('TURNITIN_RESP_CLASS_CREATED', 21); // Class Created successfully, do not send to login
-define('TURNITIN_RESP_CLASS_UPDATED', 22); // Class updated successfully
-define('TURNITIN_RESP_USER_JOINED', 31); // successful, User joined to class, do not sent to login
-define('TURNITIN_RESP_ASSIGN_CREATED', 41); // Assignment Created
-define('TURNITIN_RESP_ASSIGN_MODIFIED', 42); // Assignment modified
-define('TURNITIN_RESP_ASSIGN_DELETED', 43); // Assignment deleted
-define('TURNITIN_RESP_PAPER_SENT', 51); // paper submitted
+// Turnitin Response codes - there are many more of these, just not used directly.
+define('TURNITIN_RESP_USER_CREATED', 11); // User creation successful, do not send to login.
+define('TURNITIN_RESP_CLASS_CREATED_LOGIN', 20); // Class created successfully, send to login.
+define('TURNITIN_RESP_CLASS_CREATED', 21); // Class Created successfully, do not send to login.
+define('TURNITIN_RESP_CLASS_UPDATED', 22); // Class updated successfully.
+define('TURNITIN_RESP_USER_JOINED', 31); // Successful, User joined to class, do not sent to login.
+define('TURNITIN_RESP_ASSIGN_CREATED', 41); // Assignment Created.
+define('TURNITIN_RESP_ASSIGN_MODIFIED', 42); // Assignment modified.
+define('TURNITIN_RESP_ASSIGN_DELETED', 43); // Assignment deleted.
+define('TURNITIN_RESP_PAPER_SENT', 51); // Paper submitted.
 define('TURNITIN_RESP_SCORE_RECEIVED', 61); // Originality score retrieved.
 define('TURNITIN_RESP_ASSIGN_EXISTS', 419); // Assignment already exists.
 define('TURNITIN_RESP_SCORE_NOT_READY', 415);
 
-//get global class
+// Get global class.
 global $CFG;
 require_once($CFG->dirroot.'/plagiarism/lib.php');
 
@@ -88,17 +87,17 @@ require_once($CFG->dirroot.'/plagiarism/lib.php');
 class plagiarism_plugin_turnitin extends plagiarism_plugin {
 
     /**
-     * @param $linkarray
+     * @param array $linkarray
      * @return string
      */
-    public function get_links($linkarray) {
-        global $DB, $USER, $COURSE, $CFG;
+    public function get_links(array $linkarray) {
+
         $cmid = $linkarray['cmid'];
         $userid = $linkarray['userid'];
         $file = $linkarray['file'];
         $results = $this->get_file_results($cmid, $userid, $file);
         if (empty($results)) {
-            // Cron has not run yet
+            // Cron has not run yet.
             return '<br />';
         }
 
@@ -115,15 +114,16 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
 
         $similaritystring = '<span class="' . $rank . '">' . $results['score'] . '%</span>';
         if (!empty($results['reporturl'])) {
-            // User gets to see link to similarity report & similarity score
+            // User gets to see link to similarity report & similarity score.
             $output = '<span class="plagiarismreport"><a href="' . $results['reporturl'] . '" target="_blank">';
             $output .= get_string('similarity', 'plagiarism_turnitin').':</a>' . $similaritystring . '</span>';
         } else {
-            // User only sees similarity score
-            $output = '<span class="plagiarismreport">' . get_string('similarity', 'plagiarism_turnitin') . $similaritystring . '</span>';
+            // User only sees similarity score.
+            $output = '<span class="plagiarismreport">' . get_string('similarity', 'plagiarism_turnitin') .
+                      $similaritystring . '</span>';
         }
 
-        //now check if grademark enabled and return the status of this file.
+        // Now check if grademark enabled and return the status of this file.
         if (!empty($results['grademarklink'])) {
             $output .= '<span class="grademark">' . $results['grademarklink'] . "</span>";
         }
@@ -139,16 +139,16 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
      * @return mixed - false if no info available, or an array describing what's known about the TII submission
      */
     public function get_file_results($cmid, $userid, stored_file $file) {
-        global $DB, $USER, $COURSE, $OUTPUT;
+        global $DB, $USER, $COURSE;
 
         $plagiarismsettings = $this->get_settings();
         if (empty($plagiarismsettings)) {
-            // Turnitin is not enabled
+            // Turnitin is not enabled.
             return false;
         }
         $plagiarismvalues = $DB->get_records_menu('plagiarism_turnitin_config', array('cm'=>$cmid), '', 'name,value');
         if (empty($plagiarismvalues['use_turnitin'])) {
-            // Turnitin not in use for this cm
+            // Turnitin not in use for this cm.
             return false;
         }
 
@@ -162,7 +162,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
             $module = $DB->get_record($moduledetail->name, array('id'=>$moduledetail->instance));
         }
         if (empty($module)) {
-            // No such cmid
+            // No such cmid.
             return false;
         }
 
@@ -172,7 +172,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         $viewsimilarityscore = has_capability('plagiarism/turnitin:viewsimilarityscore', $modulecontext);
         $viewfullreport = has_capability('plagiarism/turnitin:viewfullreport', $modulecontext);
         if ($USER->id == $userid) {
-            // The user wants to see details on their own report
+            // The user wants to see details on their own report.
             if ($plagiarismvalues['plagiarism_show_student_score'] == PLAGIARISM_TII_SHOW_ALWAYS) {
                 $viewsimilarityscore = true;
             }
@@ -189,7 +189,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         $plagiarismfile = $DB->get_record('plagiarism_turnitin_files',
                 array('cm' => $cmid, 'userid' => $userid, 'identifier' => $filehash));
         if (empty($plagiarismfile)) {
-            // No record of that submission - so no links can be returned
+            // No record of that submission - so no links can be returned.
             return false;
         }
         $results = array(
@@ -198,7 +198,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                 'reporturl' => '',
                 );
         if (isset($plagiarismfile->statuscode) && $plagiarismfile->statuscode != 'success') {
-            //always display errors - even if the student isn't able to see report/score.
+            // Always display errors - even if the student isn't able to see report/score.
             $results['error'] = turnitin_error_text($plagiarismfile->statuscode);
             return $results;
         }
@@ -207,7 +207,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         $results['analyzed'] = 1;
         $results['score'] = $plagiarismfile->similarityscore;
         if ($viewfullreport) {
-            // User gets to see link to similarity report
+            // User gets to see link to similarity report.
             $results['reporturl'] = turnitin_get_report_link($plagiarismfile, $COURSE, $plagiarismsettings);
         }
 
@@ -226,19 +226,20 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
             return;
         }
         if (isset($data->use_turnitin)) {
-            //array of posible plagiarism config options.
+            // Array of possible plagiarism config options.
             $plagiarismelements = $this->config_options();
-            //first get existing values
-            $existingelements = $DB->get_records_menu('plagiarism_turnitin_config', array('cm'=>$data->coursemodule), '', 'name,id');
+            // First get existing values.
+            $params = array('cm' => $data->coursemodule);
+            $existingelements = $DB->get_records_menu('plagiarism_turnitin_config', $params, '', 'name,id');
             foreach ($plagiarismelements as $element) {
                 $newelement = new object();
                 $newelement->cm = $data->coursemodule;
                 $newelement->name = $element;
                 $newelement->value = (isset($data->$element) ? $data->$element : 0);
-                if (isset($existingelements[$element])) { //update
+                if (isset($existingelements[$element])) { // Update.
                     $newelement->id = $existingelements[$element];
                     $DB->update_record('plagiarism_turnitin_config', $newelement);
-                } else { //insert
+                } else { // Insert.
                     $DB->insert_record('plagiarism_turnitin_config', $newelement);
                 }
 
@@ -247,42 +248,47 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
     }
 
     /**
-     * @param object $mform
+     * Adds the standard form elements to the mod_form which allow Turnitin to be enabled for a module.
+     *
+     * @param MoodleQuickForm $mform
      * @param object $context
      */
     public function get_form_elements_module($mform, $context) {
-        global $CFG, $DB;
+        global $DB;
+
         if (!$this->get_settings()) {
             return;
         }
-        $cmid = optional_param('update', 0, PARAM_INT); //there doesn't seem to be a way to obtain the current cm a better way - $this->_cm is not available here.
+        // There doesn't seem to be a way to obtain the current cm a better way - $this->_cm is not available here.
+        $cmid = optional_param('update', 0, PARAM_INT);
         if (!empty($cmid)) {
             $plagiarismvalues = $DB->get_records_menu('plagiarism_turnitin_config', array('cm'=>$cmid), '', 'name,value');
         }
-        $plagiarismdefaults = $DB->get_records_menu('plagiarism_turnitin_config', array('cm'=>0), '', 'name,value'); //cmid(0) is the default list.
+        // Cmid(0) is the default list.
+        $plagiarismdefaults = $DB->get_records_menu('plagiarism_turnitin_config', array('cm'=>0), '', 'name,value');
         $plagiarismelements = $this->config_options();
         if (has_capability('plagiarism/turnitin:enable', $context)) {
             turnitin_get_form_elements($mform);
             if ($mform->elementExists('plagiarism_draft_submit')) {
                 $mform->disabledIf('plagiarism_draft_submit', 'var4', 'eq', 0);
             }
-            //disable all plagiarism elements if use_plagiarism eg 0
+            // Disable all plagiarism elements if use_plagiarism eg 0.
             foreach ($plagiarismelements as $element) {
-                if ($element <> 'use_turnitin') { //ignore this var
+                if ($element <> 'use_turnitin') { // Ignore this var.
                     $mform->disabledIf($element, 'use_turnitin', 'eq', 0);
                 }
             }
-            //check if files have already been submitted and disable exclude biblio and quoted if turnitin is enabled.
+            // Check if files have already been submitted and disable exclude biblio and quoted if turnitin is enabled.
             if ($DB->record_exists('plagiarism_turnitin_files', array('cm'=> $cmid))) {
                 $mform->disabledIf('plagiarism_exclude_biblio', 'use_turnitin');
                 $mform->disabledIf('plagiarism_exclude_quoted', 'use_turnitin');
             }
-        } else { //add plagiarism settings as hidden vars.
+        } else { // Add plagiarism settings as hidden vars.
             foreach ($plagiarismelements as $element) {
                 $mform->addElement('hidden', $element);
             }
         }
-        //now set defaults.
+        // Now set defaults.
         foreach ($plagiarismelements as $element) {
             if (isset($plagiarismvalues[$element])) {
                 $mform->setDefault($element, $plagiarismvalues[$element]);
@@ -301,7 +307,8 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
 
         $outputhtml = '';
 
-        if ($plagiarismsettings = $this->get_settings()) {
+        $plagiarismsettings = $this->get_settings();
+        if ($plagiarismsettings) {
             if (!empty($plagiarismsettings['turnitin_student_disclosure'])) {
 
                 $params = array('cm' => $cmid, 'name' => 'use_turnitin');
@@ -320,15 +327,15 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
 
     /**
      * This function should be used to initialise settings and check if plagiarism is enabled
-     * *
+     *
      * @return mixed - false if not enabled, or returns an array of relavant settings.
      */
     public function get_settings() {
-        global $DB;
+
         $plagiarismsettings = (array)get_config('plagiarism');
-        //check if tii enabled.
-        if (isset($plagiarismsettings['turnitin_use']) && $plagiarismsettings['turnitin_use'] && isset($plagiarismsettings['turnitin_accountid']) && $plagiarismsettings['turnitin_accountid']) {
-            //now check to make sure required settings are set!
+        // Check if tii enabled.
+        if (!empty($plagiarismsettings['turnitin_use']) && !empty($plagiarismsettings['turnitin_accountid'])) {
+            // Now check to make sure required settings are set!
             if (empty($plagiarismsettings['turnitin_secretkey'])) {
                 print_error('missingkey', 'plagiarism_turnitin');
             }
@@ -370,7 +377,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         $newrecord = null;
         if (!isset($USER->profile)) {
             // User has had a partial login - possibly over web services.
-            // Check for profile details directly in DB:
+            // Check for profile details directly in DB...
             $sql = 'SELECT d.id, d.data ' .
                     'FROM {user_info_field} f ' .
                     ' INNER JOIN {user_info_data} d ON d.fieldid = f.id ' .
@@ -402,22 +409,22 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         }
 
         if (!in_array($course->id, $existingcourses)) {
-            // Turnitin doesn't (yet) know that this user is a teacher in this course.  Tell them:
+            // Turnitin doesn't (yet) know that this user is a teacher in this course. Tell them.
             $tii = array();
             $tii['utp']      = TURNITIN_INSTRUCTOR;
             $tii = turnitin_get_tii_user($tii, $USER);
-            $tii['cid']      = get_config('plagiarism_turnitin_course', $course->id); //course ID
+            $tii['cid']      = get_config('plagiarism_turnitin_course', $course->id); // Course ID.
             $tii['ctl']      = (strlen($course->shortname) > 45 ? substr($course->shortname, 0, 45) : $course->shortname);
             $tii['ctl']      = (strlen($tii['ctl']) > 5 ? $tii['ctl'] : $tii['ctl']."_____");
             $tii['fcmd'] = TURNITIN_RETURN_XML;
             $tii['fid']  = TURNITIN_CREATE_CLASS;
             $tiixml = plagiarism_get_xml(turnitin_get_url($tii, $plagiarismsettings));
             if ($tiixml->rcode[0] != TURNITIN_RESP_CLASS_CREATED) {
-                return $OUTPUT->notification(get_string('errorassigninguser','plagiarism_turnitin'));
+                return $OUTPUT->notification(get_string('errorassigninguser', 'plagiarism_turnitin'));
             }
             $existingcourses[] = $course->id;
             $newcoursecache =  implode(',', $existingcourses);
-            // Now update our record of what teacherships TII knows about:
+            // Now update our record of what teacherships TII knows about.
             $userprofilefieldid = $DB->get_field('user_info_field', 'id', array('shortname'=>$userprofilefieldname));
             if ($newrecord) {
                 // New field - will need to insert a new record.
@@ -427,17 +434,19 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                 $userdata->data = $newcoursecache;
                 $DB->insert_record('user_info_data', $userdata);
             } else {
-                $DB->set_field('user_info_data', 'data', $newcoursecache, array('userid'=>$USER->id, 'fieldid'=>$userprofilefieldid));
+                $params = array('userid' => $USER->id,
+                                'fieldid' => $userprofilefieldid);
+                $DB->set_field('user_info_data', 'data', $newcoursecache, $params);
             }
 
             $USER->profile[$userprofilefieldname] = $newcoursecache;
         }
 
         $tii = array();
-        //print link to teacher login
-        $tii['fcmd'] = TURNITIN_LOGIN; //when set to 2 this returns XML
+        // Print link to teacher login.
+        $tii['fcmd'] = TURNITIN_LOGIN; // When set to 2 this returns XML.
         $tii['utp'] = TURNITIN_INSTRUCTOR;
-        $tii['fid'] = TURNITIN_CREATE_USER; //set commands - Administrator login/statistics.
+        $tii['fid'] = TURNITIN_CREATE_USER; // Set commands - Administrator login/statistics.
         $tii = turnitin_get_tii_user($tii, $USER);
         $outputhtml .= '<div style="text-align:right"><a href="'.turnitin_get_url($tii, $plagiarismsettings).'" target="_blank">'.get_string("teacherlogin","plagiarism_turnitin").'</a></div>';
 

--- a/lib.php
+++ b/lib.php
@@ -604,12 +604,13 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                     if ($files) {
                         foreach ($files as $file) {
                             /* @var stored_file $file */
-                            $fileresult = false;
                             // TODO: need to check if this file has already been sent! - possible that the file was sent
                             // before draft submit was set.
                             $pid = plagiarism_update_record($cmid, $eventdata->userid, $file->get_pathnamehash());
                             if (!empty($pid)) {
                                 $fileresult = turnitin_send_file($pid, $plagiarismsettings, $file);
+                            } else {
+                                $fileresult = true; // File already been sent.
                             }
                             $result = $fileresult && $result;
                         }
@@ -631,7 +632,6 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
             $result = true;
             foreach ($eventdata->files as $efile) {
                 /* @var stored_file $efile */
-                $fileresult = false;
                 if ($efile->get_filename() === '.') {
                     // This is a directory - nothing to do.
                     continue;

--- a/lib.php
+++ b/lib.php
@@ -528,6 +528,21 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                 mtrace("Warning: assignment start time is too early ".date('Y-m-d H:i:s', $assignmentstarttime)." cmid:". $eventdata->cmid." will delay sending files until next cron");
                 return false;
             }
+			
+			if($files = $eventdata->files) {
+				$result = true;
+				mtrace("processing event files");
+				foreach ($files as $file) {
+                    $fileresult = false;
+                    //TODO: need to check if this file has already been sent! - possible that the file was sent before draft submit was set.
+                    $pid = plagiarism_update_record($cmid, $eventdata->userid, $file->get_pathnamehash());
+                    if (!empty($pid)) {
+                        $fileresult = turnitin_send_file($pid, $plagiarismsettings, $file);
+                    }
+                    $result = $fileresult && $result;
+                }
+				return $result;
+			}
 
             if (!empty($eventdata->file) && empty($eventdata->files)) { //single assignment type passes a single file
                 $eventdata->files[] = $eventdata->file;
@@ -538,7 +553,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                 // This is a 'finalize' event - assignment-focused functionality
                 mtrace("finalise");
                 if (isset($plagiarismvalues['plagiarism_draft_submit'])
-                        && $plagiarismvalues['plagiarism_draft_submit'] == PLAGIARISM_TII_DRAFTSUBMIT_FINAL) {
+                        && $plagiarismvalues['plagiarism_draft_submit'] == PLAGIARISM_TII_DRAFTSUBMIT_FINAL) {					
                     // Drafts haven't previously been sent
                     // get assignment details, list of draft files and submit to TII.
                     require_once("$CFG->dirroot/mod/$modulename/lib.php");
@@ -548,9 +563,9 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                     $submission = $assignmentbase->get_submission($eventdata->userid);
                     $modulecontext = get_context_instance(CONTEXT_MODULE, $eventdata->cmid);
                     $fs = get_file_storage();
-                    $result = true;
-                    if ($files = $fs->get_area_files($modulecontext->id, 'mod_'.$modulename, 'submission', $submission->id, "timemodified", false)) {
-                        foreach ($files as $file) {
+					if ($files = $fs->get_area_files($modulecontext->id, 'mod_'.$modulename, 'submission', $submission->id, "timemodified", false)) {
+                        mtrace("files");
+						foreach ($files as $file) {
                             $fileresult = false;
                             //TODO: need to check if this file has already been sent! - possible that the file was sent before draft submit was set.
                             $pid = plagiarism_update_record($cmid, $eventdata->userid, $file->get_pathnamehash());

--- a/lib.php
+++ b/lib.php
@@ -533,10 +533,10 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                 return false;
             }
 
-			if($files = $eventdata->files) {
-				$result = true;
-				mtrace("processing event files");
-				foreach ($files as $file) {
+            if($files = $eventdata->files) {
+                $result = true;
+                mtrace("processing event files");
+                foreach ($files as $file) {
                     $pid = plagiarism_update_record($cmid, $eventdata->userid, $file->get_pathnamehash());
                     if (!empty($pid)) {
                         $fileresult = turnitin_send_file($pid, $plagiarismsettings, $file);
@@ -545,8 +545,8 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                     }
                     $result = $fileresult && $result;
                 }
-				return $result;
-			}
+                return $result;
+            }
 
             if (!empty($eventdata->file) && empty($eventdata->files)) { //single assignment type passes a single file
                 $eventdata->files[] = $eventdata->file;
@@ -567,10 +567,10 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                     $submission = $assignmentbase->get_submission($eventdata->userid);
                     $modulecontext = get_context_instance(CONTEXT_MODULE, $eventdata->cmid);
                     $fs = get_file_storage();
-					if ($files = $fs->get_area_files($modulecontext->id, 'mod_'.$modulename, 'submission', $submission->id, "timemodified", false)) {
+                    if ($files = $fs->get_area_files($modulecontext->id, 'mod_'.$modulename, 'submission', $submission->id, "timemodified", false)) {
                         mtrace("files");
                         $result = true;
-						foreach ($files as $file) {
+                        foreach ($files as $file) {
                             $pid = plagiarism_update_record($cmid, $eventdata->userid, $file->get_pathnamehash());
                             if (!empty($pid)) {
                                 $fileresult = turnitin_send_file($pid, $plagiarismsettings, $file);

--- a/lib.php
+++ b/lib.php
@@ -963,7 +963,10 @@ function turnitin_send_file($pid, $plagiarismsettings, $file) {
     $tii['fid']      = TURNITIN_CREATE_USER;
     $tiixml = plagiarism_get_xml(turnitin_get_url($tii, $plagiarismsettings, false, $pid));
     if (empty($tiixml->rcode[0]) or $tiixml->rcode[0] <> TURNITIN_RESP_USER_CREATED) { //this is the success code for uploading a file. - we need to return the oid and save it!
-         mtrace('could not create user/login to turnitin code:'.$tiixml->rcode[0]);
+        mtrace('could not create user/login to turnitin code:'.$tiixml->rcode[0].' '.$tiixml->rmessage);
+        turnitin_end_session($user, $plagiarismsettings, $tiisession);
+
+        return false; // Retry.
     } else {
         $plagiarism_file = $DB->get_record('plagiarism_turnitin_files', array('id'=>$pid)); //make sure we get latest record as it may have changed
         $plagiarism_file->statuscode = (string)$tiixml->rcode[0];
@@ -983,7 +986,10 @@ function turnitin_send_file($pid, $plagiarismsettings, $file) {
         //$tii2['diagnostic'] = '1';
         $tiixml = plagiarism_get_xml(turnitin_get_url($tii, $plagiarismsettings, false, $pid));
         if (empty($tiixml->rcode[0]) or $tiixml->rcode[0] <> TURNITIN_RESP_USER_JOINED) { //this is the success code for uploading a file. - we need to return the oid and save it!
-            mtrace('could not enrol user in turnitin class code:'.$tiixml->rcode[0]);
+            mtrace('could not enrol user in turnitin class code:'.$tiixml->rcode[0].' '.$tiixml->rmessage);
+            turnitin_end_session($user, $plagiarismsettings, $tiisession);
+
+            return false; // Retry.
         } else {
             $plagiarism_file = $DB->get_record('plagiarism_turnitin_files', array('id'=>$pid)); //make sure we get latest record as it may have changed
             $plagiarism_file->statuscode = (string)$tiixml->rcode[0];
@@ -1018,11 +1024,13 @@ function turnitin_send_file($pid, $plagiarismsettings, $file) {
             if (! $DB->update_record('plagiarism_turnitin_files', $plagiarism_file)) {
                 debugging("Error updating turnitin_files record");
             }
+
             turnitin_end_session($user, $plagiarismsettings, $tiisession);
 
-            return $tiixml;
+            return true;
         }
     }
+
 }
 /**
  * used to obtain similarity scores from Turnitin for submitted files.

--- a/lib.php
+++ b/lib.php
@@ -34,7 +34,7 @@ define('PLAGIARISM_TII_SHOW_CLOSED', 2);
 define('PLAGIARISM_TII_DRAFTSUBMIT_IMMEDIATE', 0);
 define('PLAGIARISM_TII_DRAFTSUBMIT_FINAL', 1);
 
-//  fcmd types - return values.
+// Fcmd types - return values.
 define('TURNITIN_LOGIN', 1);
 define('TURNITIN_RETURN_XML', 2);
 define('TURNITIN_UPDATE_RETURN_XML', 3);
@@ -1250,7 +1250,10 @@ function turnitin_error_text($statuscode, $notify=true) {
  */
 function turnitin_update_assignment($plagiarismsettings, $plagiarismvalues, $eventdata, $action) {
     global $DB;
-    $result = true;
+
+    $result = true; // Default to true as we probably don't need to update. Switch to false later if it fails.
+    $tiixml = false;
+
     if ($action=='delete') {
         // Delete function deliberately not handled (fid=8)
         // if an assignment is deleted "accidentally" we can resotre off backups - but if
@@ -1422,12 +1425,13 @@ function turnitin_update_assignment($plagiarismsettings, $plagiarismvalues, $eve
                 mtrace("Turnitin Success creating Class and assignment");
             } else {
                 mtrace("Error: could not create assignment in class statuscode:".$tiixml->rcode[0].' '.$tiixml->rmessage, 3);
-                $return = false;
+                $result = false;
             }
 
         } else {
-            mtrace("Error: could not create class and assign global instructor statuscode:".$tiixml->rcode[0]);
-            $return = false;
+            $error = !empty($tiixml->rcode[0]) ? $tiixml->rcode[0] : 'No error code';
+            mtrace("Error: could not create class and assign global instructor statuscode:".$error);
+            $result = false;
         }
     }
     turnitin_end_session($user, $plagiarismsettings, $tiisession);
@@ -1578,7 +1582,7 @@ function turnitin_get_report_link($file, $course, $plagiarismsettings) {
  * Internal function that returns xml when provided a URL
  *
  * @param string $url the url being passed.
- * @return string xml
+ * @return SimpleXMLElement|bool xml
  */
 function plagiarism_get_xml($url) {
     global $CFG;
@@ -1591,7 +1595,7 @@ function plagiarism_get_xml($url) {
         $xml = new SimpleXMLElement($fp);
         return $xml;
     }
-    return '';
+    return false;
 }
 
 /**

--- a/lib.php
+++ b/lib.php
@@ -911,6 +911,10 @@ function turnitin_end_session($user, $plagiarismsettings, $tiisession) {
  * $pid - id of this record from turnitin_files table
  * $file - contains actual file object
  *
+ * @param int $pid
+ * @param array $plagiarismsettings
+ * @param stored_file $file
+ * @return bool true means done - event can be removed from queue.
  */
 function turnitin_send_file($pid, $plagiarismsettings, $file) {
     global $DB, $CFG;
@@ -942,7 +946,7 @@ function turnitin_send_file($pid, $plagiarismsettings, $file) {
     }
     if ($invalidrecord) {
         $DB->delete_records('plagiarism_turnitin_files', array('id'=>$plagiarism_file->id));
-        return true;
+        return true; // Do not reattempt - no hope of success.
     }
     $dtstart = $DB->get_record('plagiarism_turnitin_config', array('cm' => $cm->id, 'name' => 'turnitin_dtstart'));
     if (!empty($dtstart) && $dtstart->value > time()) {

--- a/lib.php
+++ b/lib.php
@@ -82,8 +82,15 @@ define('TURNITIN_RESP_SCORE_NOT_READY', 415);
 global $CFG;
 require_once($CFG->dirroot.'/plagiarism/lib.php');
 
-///// Turnitin Class ////////////////////////////////////////////////////
+/**
+ * Turnitin Class.
+ */
 class plagiarism_plugin_turnitin extends plagiarism_plugin {
+
+    /**
+     * @param $linkarray
+     * @return string
+     */
     public function get_links($linkarray) {
         global $DB, $USER, $COURSE, $CFG;
         $cmid = $linkarray['cmid'];
@@ -124,7 +131,8 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
     }
 
     /**
-     * Get the information turnitin has about a file
+     * Get the information turnitin has about a file.
+     *
      * @param int $cmid the id of the coursemodule file was submitted for
      * @param int $userid the id of the user who submitted the file
      * @param stored_file $file file object describing a moodle file which was submited to TII
@@ -209,6 +217,9 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         return $results;
     }
 
+    /**
+     * @param $data
+     */
     public function save_form_elements($data) {
             global $DB;
         if (!$this->get_settings()) {
@@ -235,6 +246,10 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         }
     }
 
+    /**
+     * @param object $mform
+     * @param object $context
+     */
     public function get_form_elements_module($mform, $context) {
         global $CFG, $DB;
         if (!$this->get_settings()) {
@@ -277,6 +292,10 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         }
     }
 
+    /**
+     * @param int $cmid
+     * @return string
+     */
     public function print_disclosure($cmid) {
         global $DB, $OUTPUT;
 
@@ -298,6 +317,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         }
         return $outputhtml;
     }
+
     /**
      * This function should be used to initialise settings and check if plagiarism is enabled
      * *
@@ -317,6 +337,10 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
             return false;
         }
     }
+
+    /**
+     * @return array
+     */
     public function config_options() {
         return array('use_turnitin', 'plagiarism_show_student_score', 'plagiarism_show_student_report',
                      'plagiarism_draft_submit', 'plagiarism_compare_student_papers', 'plagiarism_compare_internet',
@@ -325,6 +349,11 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                      'plagiarism_exclude_matches_value', 'plagiarism_anonymity');
     }
 
+    /**
+     * @param object $course
+     * @param object $cm
+     * @return string|void
+     */
     public function update_status($course, $cm) {
         global $DB, $USER, $OUTPUT;
 
@@ -457,9 +486,9 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         }
         return $outputhtml;
     }
+
     /**
      * used by admin/cron.php to get similarity scores from submitted files.
-     *
      */
     public function cron() {
         global $CFG, $DB;
@@ -497,6 +526,11 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
             }
         }
     }
+
+    /**
+     * @param $eventdata
+     * @return bool
+     */
     public function event_handler($eventdata) {
         global $DB, $CFG;
         $plagiarismsettings = $this->get_settings();
@@ -658,7 +692,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
 //functions specific to the Turnitin plagiarism tool
 
 /**
- * generates a url including md5 for use in posting to Turnitin API.
+ * Generates a url including md5 for use in posting to Turnitin API.
  *
  * @param array $tii the intial $tii object
  * @param array $plagiarismsettings
@@ -793,7 +827,8 @@ function turnitin_get_gmtime() {
 /**
  * internal function that generates an md5 based on particular items in a $tii array - used by turnitin_get_url
  *
- * @param object $tii the intial $tii object
+ * @param array $tii the initial $tii object
+ * @param array $plagiarismsettings
  * @return string - calculated md5
  */
 function turnitin_get_md5string($tii, $plagiarismsettings) {
@@ -876,7 +911,8 @@ function turnitin_post_data($tii, $plagiarismsettings, $file='', $pid='') {
 /**
  * Function that starts Turnitin session - some api calls require this
  *
- * @param object  $plagiarismsettings - from a call to plagiarism_get_settings
+ * @param $user
+ * @param array  $plagiarismsettings - from a call to plagiarism_get_settings
  * @return string - Turnitin sessionid
  */
 function turnitin_start_session($user, $plagiarismsettings) {
@@ -1138,9 +1174,11 @@ function turnitin_get_scores($plagiarismsettings) {
 
 
 /**
- * given an error code, returns the description for this error
- * @param string statuscode The Error code.
+ * Given an error code, returns the description for this error.
+ *
+ * @param string $statuscode The Error code.
  * @param boolean $notify if true, returns a notify call - otherwise just returns the text of the error.
+ * @return string
  */
 function turnitin_error_text($statuscode, $notify=true) {
     global $OUTPUT;
@@ -1169,7 +1207,10 @@ function turnitin_error_text($statuscode, $notify=true) {
 /**
  * creates/updates the assignment within Turnitin - used by event handlers.
  *
+ * @param array $plagiarismsettings
+ * @param array $plagiarismvalues
  * @param object $eventdata - data returned in an Event
+ * @param string $action
  * @return boolean  returns false if unexpected error occurs.
  */
 function turnitin_update_assignment($plagiarismsettings, $plagiarismvalues, $eventdata, $action) {
@@ -1356,9 +1397,9 @@ function turnitin_update_assignment($plagiarismsettings, $plagiarismvalues, $eve
  * this function assumes that another process has already updated the grademark status
  *
  * @param object $plagiarismfile - record from plagiarsim_files table
- * @param object $course - course record
  * @param object $course - module record
- * @param object  $plagiarismsettings - from a call to plagiarism_get_settings
+ * @param stdClass $module
+ * @param array $plagiarismsettings - from a call to plagiarism_get_settings
  * @return string - link to grademark function including images.
  */
 function turnitin_get_grademark_link($plagiarismfile, $course, $module, $plagiarismsettings) {
@@ -1396,8 +1437,8 @@ function turnitin_get_grademark_link($plagiarismfile, $course, $module, $plagiar
 /**
  * Function that returns turnaround time for reports from Turnitin
  *
- * @param object  $plagiarismsettings - from a call to plagiarism_get_settings
- * @return xml - xml
+ * @param array $plagiarismsettings - from a call to plagiarism_get_settings
+ * @return string xml
  */
 function turnitin_get_responsetime($plagiarismsettings) {
     global $USER;
@@ -1411,9 +1452,9 @@ function turnitin_get_responsetime($plagiarismsettings) {
     return $tiixml;
 }
 /**
- * adds the list of plagiarism settings to a form
+ * Adds the list of plagiarism settings to a form
  *
- * @param object $mform - Moodle form object
+ * @param MoodleQuickForm $mform - Moodle form object
  */
 function turnitin_get_form_elements($mform) {
     $ynoptions = array( 0 => get_string('no'), 1 => get_string('yes'));
@@ -1460,7 +1501,7 @@ function turnitin_get_form_elements($mform) {
 }
 
 /**
- * generates a url to allow access to a similarity report. - helper functino for plagiarism_get_link
+ * Generates a url to allow access to a similarity report. - helper functino for plagiarism_get_link
  *
  * @param object  $file - single record from turnitin_files table
  * @param object  $course - usually global $COURSE value
@@ -1491,10 +1532,10 @@ function turnitin_get_report_link($file, $course, $plagiarismsettings) {
     return turnitin_get_url($tii, $plagiarismsettings);
 }
 /**
- * internal function that returns xml when provided a URL
+ * Internal function that returns xml when provided a URL
  *
  * @param string $url the url being passed.
- * @return xml
+ * @return string xml
  */
 function plagiarism_get_xml($url) {
     global $CFG;
@@ -1509,11 +1550,11 @@ function plagiarism_get_xml($url) {
 }
 
 /**
- * updates a turnitin_files record
+ * Updates a turnitin_files record
  *
  * @param int $cmid  - course module id
  * @param int $userid  - user id
- * @param varied $identifier  - identifier for this plagiarism record - hash of file, id of quiz question etc
+ * @param mixed $identifier  - identifier for this plagiarism record - hash of file, id of quiz question etc
  * @param int $attempt
  * @return int - id of turnitin_files record
  */
@@ -1557,7 +1598,8 @@ function plagiarism_update_record($cmid, $userid, $identifier, $attempt=0) {
 
 
 /**
- * Function that returns the name of the css class to use for a given similarity score
+ * Function that returns the name of the css class to use for a given similarity score.
+ *
  * @param integer $score - the similarity score
  * @return string - string name of css class
  */
@@ -1576,10 +1618,12 @@ function plagiarism_get_css_rank ($score) {
 
     return "rank$rank";
 }
+
 /**
- * Function used to add the user details to a Turnitin call
- * @param $tii array() $tii array passed to a get_url call
- * @param $plagiarismsettings array()  - plagiarism settings array
+ * Function used to add the user details to a Turnitin call.
+ *
+ * @param array $tii array() $tii array passed to a get_url call
+ * @param stdClass|int $user
  * @return string - string name of css class
  */
 function turnitin_get_tii_user($tii, $user) {
@@ -1597,29 +1641,50 @@ function turnitin_get_tii_user($tii, $user) {
     return $tii;
 }
 
+/**
+ * @param $eventdata
+ * @return bool
+ */
 function turnitin_event_file_uploaded($eventdata) {
     $eventdata->eventtype = 'file_uploaded';
     $turnitin = new plagiarism_plugin_turnitin();
     return $turnitin->event_handler($eventdata);
 }
+
+/**
+ * @param $eventdata
+ * @return bool
+ */
 function turnitin_event_files_done($eventdata) {
     $eventdata->eventtype = 'file_uploaded';
     $turnitin = new plagiarism_plugin_turnitin();
     return $turnitin->event_handler($eventdata);
 }
 
+/**
+ * @param $eventdata
+ * @return bool
+ */
 function turnitin_event_mod_created($eventdata) {
     $eventdata->eventtype = 'mod_created';
     $turnitin = new plagiarism_plugin_turnitin();
     return $turnitin->event_handler($eventdata);
 }
 
+/**
+ * @param $eventdata
+ * @return bool
+ */
 function turnitin_event_mod_updated($eventdata) {
     $eventdata->eventtype = 'mod_updated';
     $turnitin = new plagiarism_plugin_turnitin();
     return $turnitin->event_handler($eventdata);
 }
 
+/**
+ * @param $eventdata
+ * @return bool
+ */
 function turnitin_event_mod_deleted($eventdata) {
     $eventdata->eventtype = 'mod_deleted';
     $turnitin = new plagiarism_plugin_turnitin();

--- a/lib.php
+++ b/lib.php
@@ -567,26 +567,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                 return false;
             }
 
-            if($files = $eventdata->files) {
-                $result = true;
-                mtrace("processing event files");
-                foreach ($files as $file) {
-                    $pid = plagiarism_update_record($cmid, $eventdata->userid, $file->get_pathnamehash());
-                    if (!empty($pid)) {
-                        $fileresult = turnitin_send_file($pid, $plagiarismsettings, $file);
-                    } else {
-                        $fileresult = true; // Already sent.
-                    }
-                    $result = $fileresult && $result;
-                }
-                return $result;
-            }
-
-            if (!empty($eventdata->file) && empty($eventdata->files)) { //single assignment type passes a single file
-                $eventdata->files[] = $eventdata->file;
-            }
-
-            if (empty($eventdata->files)) {
+            if (empty($eventdata->pathnamehashes)) {
                 // There are no files attached to this 'fileuploaded' event.
                 // This is a 'finalize' event - assignment-focused functionality
                 mtrace("finalise");
@@ -628,17 +609,16 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
             // Normal scenario - this is an upload event with one or more attached files
             // Attached file(s) are to be immediately submitted to TII
             $result = true;
-            foreach ($eventdata->files as $efile) {
+            foreach ($eventdata->pathnamehashes as $hash) {
                 $fileresult = false;
-                if ($efile->get_filename() ==='.') {
-                    // This is a directory - nothing to do.
-                    continue;
-                }
-                //hacky way to check file still exists
                 $fs = get_file_storage();
-                $fileid = $fs->get_file_by_hash($efile->get_pathnamehash());
-                if (empty($fileid)) {
+                $efile = $fs->get_file_by_hash($hash);
+
+                if (empty($efile)) {
                     mtrace("nofilefound!");
+                    continue;
+                } else if ($efile->get_filename() ==='.') {
+                    // This is a directory - nothing to do.
                     continue;
                 }
 


### PR DESCRIPTION
Hi Dan.

Here it is without the messy rebase. I've branched this off the MOODLE_22_STABLE base so it won't interfere with the files stuff in master. Original comment follows.

I found a problem with our events queue getting stuck, so I've had a poke about and found that sometimes, there is an error from Turnitin e.g. user has a duplicate email, but it is not recorded in the plagiarism_turnitin_files status field. There was also a problem where the turnitin_send_file() function would return null in that case, which was causing false to get sent back to the event handler, which then stopped processing, on the assumption that Turnitin was down.

This patch fixes a few other things too. Full list:

turnitin_send_file() returns boolean all the time instead of either nothing or the XML (which is never used).
Problems e.g. cannot enrol in class also now return true so that the events clear.
The event handler has updated code so that files that are found to be already sent return true always, which takes the event out of the queue and lets the cron job take over.
There is now an option to send an array of stored files along with the event.
Fixed a problem where whitespace in the list of codes to resent was stopping them from working.
Added some PHPDoc comments.
Status codes are always saved so we can see the code if it gets stuck halfway.
Turnitin session is ended cleanly even if the process gets stuck.
Problem with undefined variable in the sanity checks in turnitin_send_file() is gone.
I'm afraid these aren't very cleanly separated into different commits, but hopefully that doesn't matter.

Matt
