### PR TITLE
Error code link

### DIFF
--- a/lang/en/plagiarism_turnitin.php
+++ b/lang/en/plagiarism_turnitin.php
@@ -121,3 +121,4 @@ $string['anonymity_help'] = 'This will prevent teachers from being able to see w
 $string['missingkey'] = 'Turnitin Secret Key not set!';
 $string['fileopenerror'] = 'error trying to open plagiarism XML file! {$a}';
 $string['beingprocessed'] = 'File was uploaded successfully and is currently being processed by turnitin';
+$string['errorlookup'] = 'See <a href ="http://docs.moodle.org/dev/Turnitin_errors">here</a> for an explanation of the code';

--- a/lib.php
+++ b/lib.php
@@ -1236,7 +1236,7 @@ function turnitin_error_text($statuscode, $notify=true) {
             // Don't have documentation on the other 1000 series errors, so just display a general one.
             $return = get_string('tiierrorpaperfail', 'plagiarism_turnitin').':'.$statuscode;
         } else if ($statuscode < 1025 || $statuscode > 2000) { // These are not errors that a student can make any sense out of.
-            $return = get_string('tiiconfigerror', 'plagiarism_turnitin').'('.$statuscode.')';
+            $return = get_string('tiiconfigerror', 'plagiarism_turnitin').' ('.$statuscode.')';
             if (has_capability('plagiarism/turnitin:enable', $PAGE->context)) {
                 $return .= html_writer::empty_tag('br');
                 $return .= get_string('errorlookup', 'plagiarism_turnitin');

--- a/lib.php
+++ b/lib.php
@@ -1218,9 +1218,15 @@ function turnitin_get_scores($plagiarismsettings) {
  * @return string
  */
 function turnitin_error_text($statuscode, $notify=true) {
-    global $OUTPUT;
+    global $OUTPUT, $CFG;
     $return = '';
     $statuscode = (int) $statuscode;
+
+    // If in developer mode, show all errors.
+    if ($CFG->debug == DEBUG_DEVELOPER) {
+        $return = get_string('tiierror'.$statuscode, 'plagiarism_turnitin');
+    }
+
     if (!empty($statuscode)) {
         if ($statuscode == 51) {
             // Let them know if it's being processes right now.

--- a/lib.php
+++ b/lib.php
@@ -1218,14 +1218,9 @@ function turnitin_get_scores($plagiarismsettings) {
  * @return string
  */
 function turnitin_error_text($statuscode, $notify=true) {
-    global $OUTPUT, $CFG;
+    global $OUTPUT, $CFG, $PAGE;
     $return = '';
     $statuscode = (int) $statuscode;
-
-    // If in developer mode, show all errors.
-    if ($CFG->debug == DEBUG_DEVELOPER) {
-        $return = get_string('tiierror'.$statuscode, 'plagiarism_turnitin');
-    }
 
     if (!empty($statuscode)) {
         if ($statuscode == 51) {
@@ -1242,6 +1237,10 @@ function turnitin_error_text($statuscode, $notify=true) {
             $return = get_string('tiierrorpaperfail', 'plagiarism_turnitin').':'.$statuscode;
         } else if ($statuscode < 1025 || $statuscode > 2000) { // These are not errors that a student can make any sense out of.
             $return = get_string('tiiconfigerror', 'plagiarism_turnitin').'('.$statuscode.')';
+            if (has_capability('plagiarism/turnitin:enable', $PAGE->context)) {
+                $return .= html_writer::empty_tag('br');
+                $return .= get_string('errorlookup', 'plagiarism_turnitin');
+            }
         }
         if (!empty($return) && $notify) {
             $return = $OUTPUT->notification($return, 'notifyproblem');


### PR DESCRIPTION
Hi Dan

Here's the right branch!

This adds a link to the Moodle docs page which explains the error code if there's one which the admin may need to interpret and they have permissions. A customer asked for this and it's a lot of help in diagnosing stuff. Maybe a bigger set of changes to get those errors into the plugin in a readable way would be better long term, but this works for now.

Matt
