### PR TITLE
Update TII plugin to support 2.4 fields

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -1500,14 +1500,19 @@ function turnitin_create_assignment($plagiarismsettings, $plagiarismvalues, $eve
             $dtstart = strtotime('+10 minutes');
             $tii['dtstart'] = rawurlencode(date($turnitindateformat, $dtstart));
         }
-        if (!empty($module->duedate) && ($module->duedate > strtotime('+10 minutes'))) {
+        if (!empty($module->cutoffdate) && ($module->cutoffdate> strtotime('+10 minutes'))) {
+            $dtdue = $module->cutoffdate;
+            $tii['dtdue'] = rawurlencode(date($turnitindateformat, $dtdue));
+            $tii['late_accept_flag']  = '0';
+        } else if (!empty($module->duedate) && ($module->duedate > strtotime('+10 minutes'))) {
             $dtdue = $module->duedate;
             $tii['dtdue'] = rawurlencode(date($turnitindateformat, $dtdue));
+            $tii['late_accept_flag']  = '1';
         } else {
             $dtdue = strtotime('+1 year');
             $tii['dtdue'] = rawurlencode(date($turnitindateformat, $dtdue));
+            $tii['late_accept_flag']  = '1';
         }
-        $tii['late_accept_flag']  = (empty($module->preventlate) ? '1' : '0');
         if (isset($module->intro) && isset($module->introformat)) {
             $intro = '';
             switch ($module->introformat) {
@@ -1688,14 +1693,19 @@ function turnitin_update_assignment($plagiarismsettings, $plagiarismvalues, $eve
             $dtstart = strtotime('+10 minutes');
             $tii['dtstart'] = rawurlencode(date($turnitindateformat, $dtstart));
         }
-        if (!empty($module->duedate) && ($module->duedate > strtotime('+10 minutes'))) {
+        if (!empty($module->cutoffdate) && ($module->cutoffdate> strtotime('+10 minutes'))) {
+            $dtdue = $module->cutoffdate;
+            $tii['dtdue'] = rawurlencode(date($turnitindateformat, $dtdue));
+            $tii['late_accept_flag']  = '0';
+        } else if (!empty($module->duedate) && ($module->duedate > strtotime('+10 minutes'))) {
             $dtdue = $module->duedate;
             $tii['dtdue'] = rawurlencode(date($turnitindateformat, $dtdue));
+            $tii['late_accept_flag']  = '1';
         } else {
             $dtdue = strtotime('+1 year');
             $tii['dtdue'] = rawurlencode(date($turnitindateformat, $dtdue));
+            $tii['late_accept_flag']  = '1';
         }
-        $tii['late_accept_flag']  = (empty($module->preventlate) ? '1' : '0');
         if (isset($module->intro) && isset($module->introformat)) {
             $intro = '';
             switch ($module->introformat) {

--- a/lib.php
+++ b/lib.php
@@ -1493,17 +1493,14 @@ function turnitin_create_assignment($plagiarismsettings, $plagiarismvalues, $eve
         $tii['assign'] = turnitin_get_assign_name($module->name, $cm->id); //assignment used on Turnitin
         $turnitindateformat = 'Y-m-d H:i:s';
         // possibly imported/restored with dates in past, why would dates be set in past, failed event?
-        if (!empty($module->timeavailable) && ($module->timeavailable > strtotime('+10 minutes'))) {
-            $dtstart = $module->timeavailable;
+        if (!empty($module->allowsubmissionsfromdate) && ($module->allowsubmissionsfromdate > strtotime('+10 minutes'))) {
+            $dtstart = $module->allowsubmissionsfromdate;
             $tii['dtstart'] = rawurlencode(date($turnitindateformat, $dtstart));
         } else {
             $dtstart = strtotime('+10 minutes');
             $tii['dtstart'] = rawurlencode(date($turnitindateformat, $dtstart));
         }
-        if (!empty($module->timedue) && ($module->timedue > strtotime('+10 minutes'))) {
-            $dtdue = $module->timedue;
-            $tii['dtdue'] = rawurlencode(date($turnitindateformat, $dtdue));
-        } else if (!empty($module->duedate) && ($module->duedate > strtotime('+10 minutes'))) {
+        if (!empty($module->duedate) && ($module->duedate > strtotime('+10 minutes'))) {
             $dtdue = $module->duedate;
             $tii['dtdue'] = rawurlencode(date($turnitindateformat, $dtdue));
         } else {
@@ -1684,17 +1681,14 @@ function turnitin_update_assignment($plagiarismsettings, $plagiarismvalues, $eve
             $tii['assign'] = $plagiarismvalues['turnitin_assign'];
         }
         $turnitindateformat = 'Y-m-d H:i:s';
-        if (!empty($module->timeavailable) && ($module->timeavailable > strtotime('+10 minutes'))) {
-            $dtstart = $module->timeavailable;
+        if (!empty($module->allowsubmissionsfromdate) && ($module->allowsubmissionsfromdate > strtotime('+10 minutes'))) {
+            $dtstart = $module->allowsubmissionsfromdate;
             $tii['dtstart'] = rawurlencode(date($turnitindateformat, $dtstart));
         } else {
             $dtstart = strtotime('+10 minutes');
             $tii['dtstart'] = rawurlencode(date($turnitindateformat, $dtstart));
         }
-        if (!empty($module->timedue) && ($module->timedue > strtotime('+10 minutes'))) {
-            $dtdue = $module->timedue;
-            $tii['dtdue'] = rawurlencode(date($turnitindateformat, $dtdue));
-        } else if (!empty($module->duedate) && ($module->duedate > strtotime('+10 minutes'))) {
+        if (!empty($module->duedate) && ($module->duedate > strtotime('+10 minutes'))) {
             $dtdue = $module->duedate;
             $tii['dtdue'] = rawurlencode(date($turnitindateformat, $dtdue));
         } else {
@@ -1806,7 +1800,6 @@ function turnitin_get_grademark_link($plagiarismfile, $course, $module, $plagiar
         return $output;
     }
     if (empty($plagiarismfile->externalstatus) ||
-       ($USER->id <> $plagiarismfile->userid && !empty($module->timedue) && $module->timedue > time()) ||
        ($USER->id <> $plagiarismfile->userid && !empty($module->duedate) && $module->duedate > time())) {
         //Grademark isn't available yet - don't provide link
         $output = '<img src="'.$OUTPUT->pix_url('i/grademark-grey').'">';

--- a/version.php
+++ b/version.php
@@ -14,8 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-$plugin->version =  2012112901;
-$plugin->requires = 2012110900.00;
+$plugin->version =  2013031400;
+$plugin->requires = 2012120300.00;
 $plugin->cron     = 300;
 $plugin->component = 'plagiarism_turnitin';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
Hi Dan,

I did some work to make it use the 2.4 fields of the assign module. I have made it only use 2.4 assign fields, not 2.3 or 2.2 fields, so it would be best to have this in another stable 2.4 branch if you wanted to go that route.
One thing I could not work out was the new "extension" added to grades now in 2.4. How would this be reuploaded to TII when you grant extension? My "solution" is to remove the permission "grantextension" and make then adjust the "cutoffdate" which updates the assignment in TII next cron.

Thanks
Alex
