### PR TITLE
Add missing compatibility with mod_assign

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -286,7 +286,8 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         if (has_capability('plagiarism/turnitin:enable', $context)) {
             turnitin_get_form_elements($mform);
             if ($mform->elementExists('plagiarism_draft_submit')) {
-                $mform->disabledIf('plagiarism_draft_submit', 'var4', 'eq', 0);
+                // Disable draft submission option if drafts are not enabled.
+                $mform->disabledIf('plagiarism_draft_submit', 'submissiondrafts', 'eq', 0);
             }
             //disable all plagiarism elements if use_plagiarism eg 0
             foreach ($plagiarismelements as $element) {
@@ -1869,7 +1870,8 @@ function turnitin_get_form_elements($mform) {
     $mform->addHelpButton('plagiarism_show_student_score', 'showstudentsscore', 'plagiarism_turnitin');
     $mform->addElement('select', 'plagiarism_show_student_report', get_string("showstudentsreport", "plagiarism_turnitin"), $tiishowoptions);
     $mform->addHelpButton('plagiarism_show_student_report', 'showstudentsreport', 'plagiarism_turnitin');
-    if ($mform->elementExists('var4')) {
+    if ($mform->elementExists('submissiondrafts')) {
+        // This appears to be the mod/assign form, so add the draft submission option.
         $mform->addElement('select', 'plagiarism_draft_submit', get_string("draftsubmit", "plagiarism_turnitin"), $tiidraftoptions);
     }
     $mform->addElement('select', 'plagiarism_compare_student_papers', get_string("comparestudents", "plagiarism_turnitin"), $ynoptions);

--- a/lib.php
+++ b/lib.php
@@ -285,9 +285,10 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         $plagiarismelements = $this->config_options();
         if (has_capability('plagiarism/turnitin:enable', $context)) {
             turnitin_get_form_elements($mform);
-            if ($mform->elementExists('plagiarism_draft_submit')) {
-                // Disable draft submission option if drafts are not enabled.
-                $mform->disabledIf('plagiarism_draft_submit', 'submissiondrafts', 'eq', 0);
+            // Disable draft submission option if drafts are not enabled.
+            $draftfield = $mform->elementExists('submissiondrafts') ? 'submissiondrafts' : 'var4';
+            if ($mform->elementExists('plagiarism_draft_submit') && $mform->elementExists($draftfield)) {
+                $mform->disabledIf('plagiarism_draft_submit', $draftfield, 'eq', 0);
             }
             //disable all plagiarism elements if use_plagiarism eg 0
             foreach ($plagiarismelements as $element) {
@@ -1882,8 +1883,8 @@ function turnitin_get_form_elements($mform) {
     $mform->addHelpButton('plagiarism_show_student_score', 'showstudentsscore', 'plagiarism_turnitin');
     $mform->addElement('select', 'plagiarism_show_student_report', get_string("showstudentsreport", "plagiarism_turnitin"), $tiishowoptions);
     $mform->addHelpButton('plagiarism_show_student_report', 'showstudentsreport', 'plagiarism_turnitin');
-    if ($mform->elementExists('submissiondrafts')) {
-        // This appears to be the mod/assign form, so add the draft submission option.
+    if ($mform->elementExists('submissiondrafts') || $mform->elementExists('var4')) {
+        // This appears to be the mod/assign(ment) form, so add the draft submission option.
         $mform->addElement('select', 'plagiarism_draft_submit', get_string("draftsubmit", "plagiarism_turnitin"), $tiidraftoptions);
     }
     $mform->addElement('select', 'plagiarism_compare_student_papers', get_string("comparestudents", "plagiarism_turnitin"), $ynoptions);

--- a/lib.php
+++ b/lib.php
@@ -658,7 +658,7 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                 return false;
             }
 
-            if (empty($eventdata->pathnamehashes) && $eventdata->eventtype=="file_done") {
+            if (empty($eventdata->pathnamehashes) && ($eventdata->eventtype=="file_done" || $eventdata->eventtype == 'assessable_submitted')) {
                 // There are no files attached to this 'fileuploaded' event.
                 // This is a 'finalize' event - assignment-focused functionality
                 mtrace("finalise");
@@ -670,12 +670,24 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
                     require_once("$CFG->dirroot/mod/$modulename/lib.php");
                     // we need to get a list of files attached to this assignment and put them in an array, so that
                     // we can submit each of them for processing.
-                    $assignmentbase = new assignment_base($cmid);
-                    $submission = $assignmentbase->get_submission($eventdata->userid);
-                    $modulecontext = get_context_instance(CONTEXT_MODULE, $eventdata->cmid);
+
+                    if ($modulename == 'assignment') {
+                        $assignmentbase = new assignment_base($cmid);
+                        $submission = $assignmentbase->get_submission($eventdata->userid);
+                        $component = 'mod_assignment';
+                        $filearea = 'submission';
+                    } else {
+                        $context = context_module::instance($cmid);
+                        $course = $DB->get_record('course', array('id' => $cm->course), '*', MUST_EXIST);
+                        $assign = new assign($context,$cm,$course);
+                        $submission = $assign->get_user_submission($eventdata->userid, false);
+                        $component = 'assignsubmission_file';
+                        $filearea = 'submission_files';
+                    }
+                    $modulecontext = get_context_instance(CONTEXT_MODULE, $cmid);
                     $fs = get_file_storage();
-                    $files = $fs->get_area_files($modulecontext->id, 'mod_'.$modulename,
-                                                 'submission', $submission->id, "timemodified", false);
+                    $files = $fs->get_area_files($modulecontext->id, $component,
+                                                 $filearea, $submission->id, "timemodified", false);
                     if ($files) {
                         mtrace("files");
                         foreach ($files as $file) {


### PR DESCRIPTION
The draft_submit option is missing from mod_assign, and the assessable_submitted event is not processed properly (no files are submitted to TII).  These patches have been tested on mod_assign (on Moodle 2.4) but not mod_assignment, though care has been taken to maintain compatibility.
