### PR TITLE
Add missing compatibility with mod_assign (master)

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -293,9 +293,10 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         $plagiarismelements = $this->config_options();
         if (has_capability('plagiarism/turnitin:enable', $context)) {
             turnitin_get_form_elements($mform);
-            if ($mform->elementExists('plagiarism_draft_submit')) {
-                // Disable draft submission option if drafts are not enabled.
-                $mform->disabledIf('plagiarism_draft_submit', 'submissiondrafts', 'eq', 0);
+            // Disable draft submission option if drafts are not enabled.
+            $draftfield = $mform->elementExists('submissiondrafts') ? 'submissiondrafts' : 'var4';
+            if ($mform->elementExists('plagiarism_draft_submit') && $mform->elementExists($draftfield)) {
+                $mform->disabledIf('plagiarism_draft_submit', $draftfield, 'eq', 0);
             }
             //disable all plagiarism elements if use_plagiarism eg 0
             foreach ($plagiarismelements as $element) {
@@ -1879,8 +1880,8 @@ function turnitin_get_form_elements($mform) {
     $mform->addHelpButton('plagiarism_show_student_score', 'showstudentsscore', 'plagiarism_turnitin');
     $mform->addElement('select', 'plagiarism_show_student_report', get_string("showstudentsreport", "plagiarism_turnitin"), $tiishowoptions);
     $mform->addHelpButton('plagiarism_show_student_report', 'showstudentsreport', 'plagiarism_turnitin');
-    if ($mform->elementExists('submissiondrafts')) {
-        // This appears to be the mod/assign form, so add the draft submission option.
+    if ($mform->elementExists('submissiondrafts') || $mform->elementExists('var4')) {
+        // This appears to be the mod/assign(ment) form, so add the draft submission option.
         $mform->addElement('select', 'plagiarism_draft_submit', get_string("draftsubmit", "plagiarism_turnitin"), $tiidraftoptions);
     }
     $mform->addElement('select', 'plagiarism_compare_student_papers', get_string("comparestudents", "plagiarism_turnitin"), $ynoptions);

--- a/lib.php
+++ b/lib.php
@@ -294,7 +294,8 @@ class plagiarism_plugin_turnitin extends plagiarism_plugin {
         if (has_capability('plagiarism/turnitin:enable', $context)) {
             turnitin_get_form_elements($mform);
             if ($mform->elementExists('plagiarism_draft_submit')) {
-                $mform->disabledIf('plagiarism_draft_submit', 'var4', 'eq', 0);
+                // Disable draft submission option if drafts are not enabled.
+                $mform->disabledIf('plagiarism_draft_submit', 'submissiondrafts', 'eq', 0);
             }
             //disable all plagiarism elements if use_plagiarism eg 0
             foreach ($plagiarismelements as $element) {
@@ -1866,7 +1867,8 @@ function turnitin_get_form_elements($mform) {
     $mform->addHelpButton('plagiarism_show_student_score', 'showstudentsscore', 'plagiarism_turnitin');
     $mform->addElement('select', 'plagiarism_show_student_report', get_string("showstudentsreport", "plagiarism_turnitin"), $tiishowoptions);
     $mform->addHelpButton('plagiarism_show_student_report', 'showstudentsreport', 'plagiarism_turnitin');
-    if ($mform->elementExists('var4')) {
+    if ($mform->elementExists('submissiondrafts')) {
+        // This appears to be the mod/assign form, so add the draft submission option.
         $mform->addElement('select', 'plagiarism_draft_submit', get_string("draftsubmit", "plagiarism_turnitin"), $tiidraftoptions);
     }
     $mform->addElement('select', 'plagiarism_compare_student_papers', get_string("comparestudents", "plagiarism_turnitin"), $ynoptions);


### PR DESCRIPTION
PR #52 for master:

The draft_submit option is missing from mod_assign, and the assessable_submitted event is not processed properly (no files are submitted to TII). These patches have been tested on mod_assign (on Moodle 2.4) but not mod_assignment, though care has been taken to maintain compatibility.
